### PR TITLE
Adding create and get payment tests

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
@@ -698,5 +698,44 @@ class PaymentFactory {
 
             return outputInitiation
         }
+
+        fun mapOBWriteFileConsentResponse4DataInitiationToOBWriteFile2DataInitiation
+                    (inputInitiation:  OBWriteFile2DataInitiation): OBWriteFile2DataInitiation? {
+            val outputInitiation = OBWriteFile2DataInitiation()
+                .fileHash(inputInitiation.fileHash)
+                .fileReference(inputInitiation.fileReference)
+                .fileType(inputInitiation.fileType)
+                .numberOfTransactions(inputInitiation.numberOfTransactions)
+                .requestedExecutionDateTime(inputInitiation.requestedExecutionDateTime)
+                .localInstrument(inputInitiation.localInstrument)
+                .controlSum(inputInitiation.controlSum)
+
+
+            if (inputInitiation.debtorAccount != null) {
+                outputInitiation.debtorAccount(
+                    OBWriteDomestic2DataInitiationDebtorAccount()
+                        .schemeName(inputInitiation.debtorAccount?.schemeName)
+                        .identification(inputInitiation.debtorAccount?.identification)
+                        .name(inputInitiation.debtorAccount?.name)
+                        .secondaryIdentification(inputInitiation.debtorAccount?.secondaryIdentification)
+                )
+            }
+
+            if (inputInitiation.remittanceInformation != null) {
+                outputInitiation.remittanceInformation(
+                    OBWriteDomestic2DataInitiationRemittanceInformation()
+                        .unstructured(inputInitiation.remittanceInformation?.unstructured)
+                        .reference(inputInitiation.remittanceInformation?.reference)
+                )
+            }
+
+            if (inputInitiation.supplementaryData != null) {
+                outputInitiation.supplementaryData(
+                    OBSupplementaryData1()
+                )
+            }
+
+            return outputInitiation
+        }
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
@@ -1,0 +1,364 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8
+
+import assertk.assertThat
+import assertk.assertions.*
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.data.AccessToken
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.http.fuel.defaultMapper
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
+import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
+import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
+import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.*
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteFileConsentResponse4DataInitiationToOBWriteFile2DataInitiation
+
+import com.github.kittinunf.fuel.core.FuelError
+import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.payment.*
+import java.math.BigDecimal
+
+class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
+
+    private val createFilePaymentConsentsApi = CreateFilePaymentsConsents(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateFilePayment
+
+    fun createFilePaymentTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        // When
+        val result = submitFilePayment(consentRequest)
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.data.charges).isNotNull().isNotEmpty()
+        assertThat(result.data.consentId).isNotEmpty()
+    }
+
+    fun createFilePayment_mandatoryFieldsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithMandatoryFieldsAndFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        // When
+        val result = submitFilePayment(consentRequest)
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.data.consentId).isNotEmpty()
+        assertThat(result.data.creationDateTime).isNotNull()
+        assertThat(result.data.filePaymentId).isNotNull().isNotEmpty()
+        assertThat(result.data.status).isNotNull()
+        assertThat(result.data.statusUpdateDateTime).isNotNull()
+        assertThat(result.data.initiation.fileHash).isNotNull().isNotEmpty()
+        assertThat(result.data.initiation.fileType).isNotNull().isNotEmpty()
+        assertThat(result.data.initiation.fileType).isIn("UK.OBIE.PaymentInitiation.3.1", "UK.OBIE.pain.001.001.08")
+    }
+
+    fun shouldCreateFilePayment_throwsFilePaymentAlreadyExistsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        // When
+        val patchedConsent = getPatchedConsent(consent)
+        // Submit first payment
+        submitFilePaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            // Verify we fail to submit a second payment
+            submitFilePaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+        }
+
+        // Then
+        assertThat(exception.message.toString()).contains(PAYMENT_SUBMISSION_ALREADY_EXISTS)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(403)
+    }
+
+    fun shouldCreateFilePayment_throwsSendInvalidFormatDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    fun shouldCreateFilePayment_throwsNoDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(null).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    fun shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    fun shouldCreateFilePayment_throwsSendInvalidKidDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val patchedConsent = getPatchedConsent(consent)
+        val filePaymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+
+        patchedConsent.data.consentId = INVALID_CONSENT_ID
+        val filePaymentSubmissionRequestWithInvalidConsentId = createFilePaymentRequest(patchedConsent)
+
+        val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(filePaymentSubmissionRequestWithInvalidConsentId)
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                filePaymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+
+        patchedConsent.data.initiation.controlSum = BigDecimal("123123")
+        val paymentSubmissionInvalidAmount = createFilePaymentRequest(patchedConsent)
+
+        val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun submitFilePayment(consentRequest: OBWriteFileConsent3): OBWriteFileResponse3 {
+        val (consent, authorizationToken) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+            consentRequest
+        )
+        return submitFilePayment(consent, authorizationToken)
+    }
+
+    private fun submitFilePayment(
+        consentResponse: OBWriteFileConsentResponse4,
+        authorizationToken: AccessToken
+    ): OBWriteFileResponse3 {
+        val patchedConsent = getPatchedConsent(consentResponse)
+        return submitFilePaymentForPatchedConsent(patchedConsent, authorizationToken)
+    }
+
+    private fun getPatchedConsent(consent: OBWriteFileConsentResponse4): OBWriteFileConsentResponse4 {
+        return createFilePaymentConsentsApi.getPatchedConsent(consent)
+    }
+
+    private fun submitFilePaymentForPatchedConsent(
+        patchedConsent: OBWriteFileConsentResponse4,
+        authorizationToken: AccessToken
+    ): OBWriteFileResponse3 {
+        val paymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+        return paymentApiClient.submitPayment(
+            createPaymentUrl,
+            authorizationToken,
+            paymentSubmissionRequest
+        )
+    }
+
+    private fun createFilePaymentRequest(patchedConsent: OBWriteFileConsentResponse4): OBWriteFile2 {
+        return OBWriteFile2().data(
+            OBWriteFile2Data()
+                .consentId(patchedConsent.data.consentId)
+                .initiation(mapOBWriteFileConsentResponse4DataInitiationToOBWriteFile2DataInitiation(patchedConsent.data.initiation))
+        )
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/api/v3_1_8/GetFilePayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/api/v3_1_8/GetFilePayment.kt
@@ -1,0 +1,86 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8
+
+import assertk.assertThat
+import assertk.assertions.isIn
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory
+import com.forgerock.uk.openbanking.support.payment.PaymentFileType
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
+import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3
+
+class GetFilePayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
+
+    private val createFilePaymentApi = CreateFilePayment(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
+
+    fun getFilePaymentsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        val filePaymentResponse = createFilePaymentApi.submitFilePayment(consentRequest)
+
+        // When
+        val getFilePaymentResponse = getFilePayment(filePaymentResponse)
+
+        // Then
+        assertThat(getFilePaymentResponse).isNotNull()
+        assertThat(getFilePaymentResponse.data.filePaymentId).isNotEmpty()
+        assertThat(getFilePaymentResponse.data.creationDateTime).isNotNull()
+        assertThat(getFilePaymentResponse.data.charges).isNotNull().isNotEmpty()
+        Assertions.assertThat(getFilePaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
+    }
+
+    fun getFilePayments_mandatoryFieldsTest() {
+        // Given
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithMandatoryFieldsAndFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        val filePaymentResponse = createFilePaymentApi.submitFilePayment(consentRequest)
+
+        // When
+        val getFilePaymentResponse = getFilePayment(filePaymentResponse)
+
+        // Then
+        assertThat(getFilePaymentResponse).isNotNull()
+        assertThat(getFilePaymentResponse.data).isNotNull()
+        assertThat(getFilePaymentResponse.data.consentId).isNotEmpty()
+        assertThat(getFilePaymentResponse.data.creationDateTime).isNotNull()
+        assertThat(getFilePaymentResponse.data.statusUpdateDateTime).isNotNull()
+        assertThat(getFilePaymentResponse.data.initiation.fileHash).isNotNull().isNotEmpty()
+        assertThat(getFilePaymentResponse.data.initiation.fileType).isNotNull().isNotEmpty()
+        assertThat(getFilePaymentResponse.data.initiation.fileType).isIn(
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type, PaymentFileType.UK_OBIE_PAYMENT_INITIATION_V3_1.type
+        )
+        assertThat(getFilePaymentResponse.data.filePaymentId).isNotEmpty()
+        Assertions.assertThat(getFilePaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
+
+    }
+
+
+    private fun getFilePayment(filePaymentResponse: OBWriteFileResponse3): OBWriteFileResponse3 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithFilePaymentId(
+            paymentLinks.GetFilePayment,
+            filePaymentResponse.data.consentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -1,4 +1,4 @@
-package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8
 
 import assertk.assertThat
 import assertk.assertions.*

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
@@ -1,4 +1,4 @@
-package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/GetFilePaymentsConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/CreateFilePaymentConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/GetFilePaymentsConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/CreateFilePaymentConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/GetFilePaymentsConsentsTest.kt
@@ -3,7 +3,7 @@ package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.cons
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePaymentsConsents
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_10/CreateFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_10/CreateFilePaymentTest.kt
@@ -1,0 +1,119 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createFilePayment: CreateFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        createFilePayment = CreateFilePayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun createFilePayment_v3_1_10() {
+        createFilePayment.createFilePaymentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun createFilePayment_mandatoryFields_v3_1_10() {
+        createFilePayment.createFilePayment_mandatoryFieldsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsFilePaymentAlreadyExists_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsFilePaymentAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNoDetachedJws_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_10/GetFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_10/GetFilePaymentTest.kt
@@ -1,0 +1,41 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getFilePayment: GetFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        getFilePayment = GetFilePayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun getFilePayments_v3_1_10() {
+        getFilePayment.getFilePaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun getFilePayments_mandatoryFields_v3_1_10() {
+        getFilePayment.getFilePayments_mandatoryFieldsTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_8/CreateFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_8/CreateFilePaymentTest.kt
@@ -1,0 +1,128 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_8
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createFilePayment: CreateFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        createFilePayment = CreateFilePayment(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createFilePayment_v3_1_8() {
+        createFilePayment.createFilePaymentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createFilePayment_mandatoryFields_v3_1_8() {
+        createFilePayment.createFilePayment_mandatoryFieldsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsFilePaymentAlreadyExists_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsFilePaymentAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidFormatDetachedJws_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNoDetachedJws_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidKidDetachedJws_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_8() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_8/GetFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_8/GetFilePaymentTest.kt
@@ -1,0 +1,43 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_8
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getFilePayment: GetFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        getFilePayment = GetFilePayment(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getFilePayments_v3_1_8() {
+        getFilePayment.getFilePaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getFilePayments_mandatoryFields_v3_1_8() {
+        getFilePayment.getFilePayments_mandatoryFieldsTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_9/CreateFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_9/CreateFilePaymentTest.kt
@@ -1,0 +1,119 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.CreateFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createFilePayment: CreateFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        createFilePayment = CreateFilePayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun createFilePayment_v3_1_9() {
+        createFilePayment.createFilePaymentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun createFilePayment_mandatoryFields_v3_1_9() {
+        createFilePayment.createFilePayment_mandatoryFieldsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsFilePaymentAlreadyExists_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsFilePaymentAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNoDetachedJws_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_9/GetFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/junit/v3_1_9/GetFilePaymentTest.kt
@@ -1,0 +1,41 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.api.v3_1_8.GetFilePayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getFilePayment: GetFilePayment
+
+    @BeforeEach
+    fun setUp() {
+        getFilePayment = GetFilePayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun getFilePayments_v3_1_9() {
+        getFilePayment.getFilePaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetFilePayment", "CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun getFilePayments_mandatoryFields_v3_1_9() {
+        getFilePayment.getFilePayments_mandatoryFieldsTest()
+    }
+
+}


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/563

Adding create payment tests and arranging consent tests in packages to follow the other packages naming and structure.