### PR TITLE
839: Using new sapig and mtls.sapig domains

### DIFF
--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -43,7 +43,7 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
 val environment by extra("dev")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
-val igServer by extra("https://obdemo.$environment.forgerock.financial")
+val igServer by extra("https://sapig.$environment.forgerock.financial")
 
 // PSU User configuration
 // needs to be a UUID and match with the value set in the use data initialiser

--- a/src/test/kotlin/com/forgerock/securebanking/framework/configuration/Config.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/framework/configuration/Config.kt
@@ -4,7 +4,9 @@ import com.forgerock.uk.openbanking.support.registerPSU
 import com.forgerock.uk.openbanking.support.registration.UserRegistrationRequest
 
 val PLATFORM_SERVER = System.getenv("platformServer") ?: "https://iam.dev.forgerock.financial"
-val IG_SERVER = System.getenv("igServer") ?: "https://obdemo.dev.forgerock.financial"
+val IG_SERVER = System.getenv("igServer") ?: "https://sapig.dev.forgerock.financial"
+// mtls is a subdomain of the gateway domain
+val MTLS_SERVER = IG_SERVER.replace("https://", "https://mtls.")
 
 val TRUSTSTORE_PATH = System.getenv("truststorePath") ?: "/com/forgerock/securebanking/truststore.jks"
 val TRUSTSTORE_PASSWORD = System.getenv("truststorePassword") ?: "changeit"

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/discovery/RsDiscovery.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/discovery/RsDiscovery.kt
@@ -1,6 +1,6 @@
 package com.forgerock.uk.openbanking.support.discovery
 
-import com.forgerock.securebanking.framework.configuration.IG_SERVER
+import com.forgerock.securebanking.framework.configuration.MTLS_SERVER
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.isSuccessful
@@ -259,7 +259,7 @@ val rsDiscoveryEnabledOperationsMap by lazy {
 }
 
 private fun getRsConfiguration(): RsDiscovery {
-    val (_, response, result) = Fuel.get("$IG_SERVER/rs/open-banking/discovery")
+    val (_, response, result) = Fuel.get("$MTLS_SERVER/rs/open-banking/discovery")
         .responseObject<RsDiscovery>(gsonDeserializer())
     if (!response.isSuccessful) throw AssertionError("Failed to load RS Discovery", result.component2())
     return result.get()


### PR DESCRIPTION
IG_SERVER has moved from obdemo subdomain to sapig subdomain

Adding MTLS_SERVER config, this is on the mtls subdomain of the gateway domain.

Using MTLS_SERVER config when doing RS discovery. All calls to RS must use mtls, the discovery doc will then return mtls urls for the tests to use.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/839