### PR TITLE
874: Testing Funds Confirmation response self links

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -25,7 +25,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         val consentRequest = aValidOBWriteDomesticConsent4()
         consentRequest.data.initiation.instructedAmount.amount("1000000")
         // When
-        val result = createConsentAndGetFundsConfirmation(consentRequest)
+        val (result, consent) = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -33,6 +33,10 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(result.data.fundsAvailableResult).isNotNull()
         assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
+        assertThat(result.links.self.toString()).isEqualTo( PaymentFactory.urlWithConsentId(
+                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+        ))
     }
 
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType() {
@@ -88,7 +92,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         val consentRequest = aValidOBWriteDomesticConsent4()
         consentRequest.data.initiation.instructedAmount.amount("3")
         // When
-        val result = createConsentAndGetFundsConfirmation(consentRequest)
+        val (result, consent) = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -96,13 +100,17 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(result.data.fundsAvailableResult).isNotNull()
         assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
+        assertThat(result.links.self.toString()).isEqualTo( PaymentFactory.urlWithConsentId(
+                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+        ))
     }
 
-    private fun createConsentAndGetFundsConfirmation(consentRequest: OBWriteDomesticConsent4): OBWriteFundsConfirmationResponse1 {
+    private fun createConsentAndGetFundsConfirmation(consentRequest: OBWriteDomesticConsent4): Pair<OBWriteFundsConfirmationResponse1, OBWriteDomesticConsentResponse5> {
         val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
             consentRequest
         )
-        return getFundsConfirmation(consent, accessTokenAuthorizationCode)
+        return getFundsConfirmation(consent, accessTokenAuthorizationCode) to consent
     }
 
     private fun getFundsConfirmation(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsentsFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsentsFundsConfirmation.kt
@@ -33,7 +33,7 @@ class GetDomesticVrpConsentsFundsConfirmation(
         consentRequest.data.controlParameters.maximumIndividualAmount.amount("1000000")
 
         // When
-        val result = createConsentAndGetFundsConfirmation(consentRequest)
+        val (result, consent) = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -41,6 +41,10 @@ class GetDomesticVrpConsentsFundsConfirmation(
         assertThat(result.data.fundsAvailableResult).isNotNull()
         assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
+        assertThat(result.links.self.toString()).isEqualTo( PaymentFactory.urlWithConsentId(
+                paymentLinks.GetDomesticVRPConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+        ))
     }
 
     fun shouldGetDomesticVrpPaymentConsentsFundsConfirmation_throwsWrongGrantType() {
@@ -68,7 +72,7 @@ class GetDomesticVrpConsentsFundsConfirmation(
         val consentRequest = aValidOBDomesticVRPConsentRequest()
         consentRequest.data.controlParameters.maximumIndividualAmount.amount("5")
         // When
-        val result = createConsentAndGetFundsConfirmation(consentRequest)
+        val (result, consent) = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -76,13 +80,17 @@ class GetDomesticVrpConsentsFundsConfirmation(
         assertThat(result.data.fundsAvailableResult).isNotNull()
         assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
+        assertThat(result.links.self.toString()).isEqualTo( PaymentFactory.urlWithConsentId(
+                paymentLinks.GetDomesticVRPConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+        ))
     }
 
-    private fun createConsentAndGetFundsConfirmation(consentRequest: OBDomesticVRPConsentRequest): OBWriteFundsConfirmationResponse1 {
+    private fun createConsentAndGetFundsConfirmation(consentRequest: OBDomesticVRPConsentRequest): Pair<OBWriteFundsConfirmationResponse1, OBDomesticVRPConsentResponse> {
         val (consent, accessTokenAuthorizationCode) = createDomesticVrpConsentsApi.createDomesticVrpConsentAndAuthorize(
             consentRequest
         )
-        return getFundsConfirmation(consent, accessTokenAuthorizationCode)
+        return getFundsConfirmation(consent, accessTokenAuthorizationCode) to consent
     }
 
     private fun getFundsConfirmation(


### PR DESCRIPTION
Asserting that the Domestic Payment and Domestic VRP Payment funds confirmation response contains valid self link.

https://github.com/SecureApiGateway/SecureApiGateway/issues/874