### PR TITLE
874: Testing Payments Self Links are valid

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -41,6 +41,7 @@ class CreateDomesticPayment(
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
+        assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.domesticPaymentId)
     }
 
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExistsTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -39,6 +39,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(paymentResponse.data).isNotNull()
         assertThat(paymentResponse.data.charges).isNotNull().isNotEmpty()
         assertThat(paymentResponse.data.consentId).isNotEmpty()
+        assertThat(paymentResponse.links.self.toString()).isEqualTo(createPaymentUrl + "/" + paymentResponse.data.domesticScheduledPaymentId)
     }
 
     fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -40,6 +40,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         assertThat(result.data).isNotNull()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
         assertThat(result.data.consentId).isNotEmpty()
+        assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.domesticStandingOrderId)
     }
 
     fun createDomesticStandingOrder_mandatoryFieldsTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -41,6 +41,7 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
+        assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.domesticVRPId)
     }
 
     fun limitBreachSimulationDomesticVrpPaymentTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
@@ -39,6 +39,7 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         assertThat(result.data).isNotNull()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
         assertThat(result.data.consentId).isNotEmpty()
+        assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.filePaymentId)
     }
 
     fun createFilePayment_mandatoryFieldsTest() {


### PR DESCRIPTION
Adding an assertion to tests which create Payments to validate the the self link in the OB response object is valid.

https://github.com/SecureApiGateway/SecureApiGateway/issues/874