### PR TITLE
575: Adding functional tests support for Risk validation

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/errors/Errors.kt
@@ -15,4 +15,5 @@ const val LOCATION_HEADER_ERROR = "Location header contains an error"
 const val LOCATION_HEADER_NOT_EXISTS = "Location header doesn't exist"
 const val CONSENT_NOT_AUTHORISED = "Resource Owner did not authorize the request"
 const val BAD_REQUEST = "Bad Request"
+const val INVALID_RISK = "Payment invalid. Payment risk received doesn't match the risk payment request"
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -256,7 +256,7 @@ class CreateDomesticPayment(
         // Alter Risk Merchant
         patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
 
-        // Submit first payment
+        // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
         }
@@ -299,9 +299,9 @@ class CreateDomesticPayment(
 
     private fun createPaymentRequest(patchedConsent: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
         return OBWriteDomestic2().data(
-                OBWriteDomestic2Data()
-                        .consentId(patchedConsent.data.consentId)
-                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
+            OBWriteDomestic2Data()
+                .consentId(patchedConsent.data.consentId)
+                .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
@@ -103,4 +103,15 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidRisk_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidRiskTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
@@ -105,4 +105,15 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidRisk_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidRiskTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -18,6 +18,7 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.common.OBRisk1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
@@ -102,7 +103,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
                 .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
@@ -128,7 +133,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
                 .configureJwsSignatureProducer(null).sendRequest()
         }
 
@@ -154,7 +163,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
                 .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
@@ -180,7 +193,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
                 .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
@@ -214,7 +231,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, standingOrderSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                standingOrderSubmissionRequest
+            )
                 .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
@@ -248,7 +269,11 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(
+                createPaymentUrl,
+                accessTokenAuthorizationCode,
+                paymentSubmissionRequest
+            )
                 .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
@@ -292,7 +317,15 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         return OBWriteDomesticStandingOrder3().data(
             OBWriteDomesticStandingOrder3Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+                .initiation(
+                    mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation(
+                        patchedConsent.data.initiation
+                    )
+                )
+        ).risk(
+            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
+                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
+                .paymentContextCode(patchedConsent.risk.paymentContextCode)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
@@ -116,4 +116,15 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsInvalidRiskTest_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidRiskTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -137,5 +137,4 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     fun shouldCreateDomesticVrp_throwsPolicyValidationErrorConsent_v3_1_10() {
         createDomesticVrpPayment.shouldCreateDomesticVrp_throwsPolicyValidationErrorTest()
     }
-
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
@@ -136,4 +136,15 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createInternationalPayment.shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayments_throwsInvalidRiskTest_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayments_throwsInvalidRiskTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -14,10 +14,11 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.BadJwsSignatureProducer
 import com.forgerock.sapi.gateway.ob.uk.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.sapi.gateway.ob.uk.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory.Companion.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation
-import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.common.OBRisk1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
@@ -359,6 +360,10 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
                         patchedConsent.data.initiation
                     )
                 )
+        ).risk(
+            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
+                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
+                .paymentContextCode(patchedConsent.risk.paymentContextCode)
         )
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -320,6 +320,34 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(com.forgerock.sapi.gateway.ob.uk.framework.errors.UNAUTHORIZED)
     }
 
+    fun shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest() {
+        // Given
+        val consentRequest = OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+            consentRequest
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        // When
+        val patchedConsent = getPatchedConsent(consent)
+
+        // Alter Risk Merchant
+        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+
+        // Submit payment
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        }
+
+        // Then
+        assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_RISK)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+    }
+
     fun submitPayment(consentRequest: OBWriteInternationalScheduledConsent5): OBWriteInternationalScheduledResponse5 {
         val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
@@ -8,6 +8,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
+import uk.org.openbanking.datamodel.common.OBRisk1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5
 
@@ -206,6 +207,10 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
                         patchedConsent.data.initiation
                     )
                 )
+        ).risk(
+            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
+                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
+                .paymentContextCode(patchedConsent.risk.paymentContextCode)
         )
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
@@ -138,4 +138,15 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/CreateInternationalStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/CreateInternationalStandingOrderTest.kt
@@ -116,4 +116,15 @@ class CreateInternationalStandingOrderTest(val tppResource: CreateTppCallback.Tp
     fun shouldCreateInternationalStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createInternationalStandingOrder.shouldCreateInternationalStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalStandingOrder", "CreateInternationalStandingOrderConsent", "GetInternationalStandingOrderConsent"],
+        apis = ["international-standing-orders", "international-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalStandingOrder_throwsInvalidRiskTest_v3_1_10() {
+        createInternationalStandingOrder.shouldCreateInternationalStandingOrder_throwsInvalidRiskTest()
+    }
 }


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/575
Description:
- Fixed tests that had the risk object missing or had the risk object mismatching between consent request and submit payment request.
- Added Risk validation functional tests support.