### PR TITLE
932: Prepare for release 0.9.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,9 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
  * Global Variables
  */
 // project version
-version = "1.0.0"
+version = "0.9.1"
 // commit hash or release name to find the proper library aligned with the services deployed on a cluster
-val release = "1.0.0"
+val release = "0.9.1"
 val jaxbVersion = "2.2.11"
 
 plugins {
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:0.9.0-SNAPSHOT"))
+    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:0.9.1"))
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-shared")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel")


### PR DESCRIPTION
And set versions to 0.9.1

Issue: https://github.com/secureapigateway/secureapigateway/issues/932