### PR TITLE
940: Fixing the policy validation CreateDomesticVrp functional test

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -303,8 +303,8 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
         }
 
         // Then
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
-        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(com.forgerock.sapi.gateway.ob.uk.framework.errors.UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(com.forgerock.sapi.gateway.ob.uk.framework.errors.BAD_REQUEST)
     }
 
     fun submitPayment(consentRequest: OBDomesticVRPConsentRequest): OBDomesticVRPResponse {


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/940
Description: Fixed the failing test on the Domestic VRPs API in order to match the OB spec (the Initiation section of the request must match the Initiation section of the corresponding consent request.).