### PR TITLE
Fixes and improvements to support validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gradle/profiles/*
 !gradle/profiles/profile-nightly.gradle.kts
 
 /certificates
+temp

--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -40,7 +40,7 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
  * Functional tests configuration
  */
 // servers
-val environment by extra("jorgesanchezperez")
+val environment by extra("dev")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
 val igServer by extra("https://sapig.$environment.forgerock.financial")

--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -40,7 +40,7 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
  * Functional tests configuration
  */
 // servers
-val environment by extra("dev")
+val environment by extra("jorgesanchezperez")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
 val igServer by extra("https://sapig.$environment.forgerock.financial")

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -22,8 +22,8 @@ import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class CreateDomesticPayment(
-    val version: OBVersion,
-    val tppResource: CreateTppCallback.TppResource
+        val version: OBVersion,
+        val tppResource: CreateTppCallback.TppResource
 ) {
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
@@ -47,24 +47,23 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExistsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, authorizationToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        submitPaymentForConsent(consentResponse, authorizationToken)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -75,21 +74,21 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -100,21 +99,21 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsNoDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(null).sendRequest()
+                    .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -125,21 +124,21 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
+                    .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -150,21 +149,21 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
+                    .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -175,29 +174,28 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
+                defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -208,29 +206,28 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = createPaymentRequest(patchedConsent)
+        consentResponse.data.initiation.instructedAmount.amount = "123123"
+        val paymentSubmissionInvalidAmount = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
+                defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
@@ -241,24 +238,23 @@ class CreateDomesticPayment(
     fun shouldCreateDomesticPayments_throwsInvalidRiskTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, authorizationToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -268,40 +264,35 @@ class CreateDomesticPayment(
 
     fun submitPayment(consentRequest: OBWriteDomesticConsent4): OBWriteDomesticResponse5 {
         val (consent, authorizationToken) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
-            consentRequest
+                consentRequest
         )
         return submitPayment(consent, authorizationToken)
     }
 
     fun submitPayment(
-        consentResponse: OBWriteDomesticConsentResponse5,
-        authorizationToken: AccessToken
+            consentResponse: OBWriteDomesticConsentResponse5,
+            authorizationToken: AccessToken
     ): OBWriteDomesticResponse5 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        return submitPaymentForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteDomesticConsentResponse5): OBWriteDomesticConsentResponse5 {
-        return createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
-    }
-
-    private fun submitPaymentForPatchedConsent(
-        patchedConsent: OBWriteDomesticConsentResponse5,
-        authorizationToken: AccessToken
+    private fun submitPaymentForConsent(
+            consentResponse: OBWriteDomesticConsentResponse5,
+            authorizationToken: AccessToken
     ): OBWriteDomesticResponse5 {
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
         return paymentApiClient.submitPayment(
-            createPaymentUrl,
-            authorizationToken,
-            paymentSubmissionRequest
+                createPaymentUrl,
+                authorizationToken,
+                paymentSubmissionRequest
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
+    private fun createPaymentRequest(consentResponse: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
         return OBWriteDomestic2().data(
-            OBWriteDomestic2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+                OBWriteDomestic2Data()
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(consentResponse.data.initiation))
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -242,18 +242,4 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         )
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteDomesticConsentResponse5): OBWriteDomesticConsentResponse5 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticConsentResponse5>(
-            paymentLinks.GetDomesticPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -62,11 +62,11 @@ class GetDomesticPaymentsConsentFundsConfirmation(
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
             consentRequest
         )
-        val patchedConsent = createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         val payment: OBWriteDomesticResponse5 = paymentApiClient.submitPayment(
             paymentLinks.CreateDomesticPayment,
@@ -79,7 +79,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            getFundsConfirmation(consent, accessTokenAuthorizationCode)
+            getFundsConfirmation(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -125,11 +125,11 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
+    private fun createPaymentRequest(consentResponse: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
         return OBWriteDomestic2().data(
                 OBWriteDomestic2Data()
-                        .consentId(patchedConsent.data.consentId)
-                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(consentResponse.data.initiation))
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
@@ -1,7 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.payments.consents.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -16,52 +15,32 @@ class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: Creat
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
-    
+
     fun shouldGetDomesticPaymentsConsents() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
-
+        val consentResponse = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 
     fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccountTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
         consentRequest.data.initiation.debtorAccount(null)
-
-        val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.debtorAccount).isNull()
-
-        // When
-        val result = createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
-
+        // when
+        val consentResponse = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
-        assertThat(result.data.initiation.debtorAccount).isNull()
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.debtorAccount).isNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -45,22 +45,21 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitPaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+        submitPaymentForConsent(consentResponse, accessTokenAuthorizationCode)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitPaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+            submitPaymentForConsent(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -71,21 +70,21 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
@@ -95,21 +94,21 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(null).sendRequest()
+                    .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -120,21 +119,21 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
+                    .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -145,21 +144,21 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
+                    .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -170,29 +169,28 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
+                defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -203,29 +201,28 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = createPaymentRequest(patchedConsent)
+        consentResponse.data.initiation.instructedAmount.amount = "123123"
+        val paymentSubmissionInvalidAmount = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
+                defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
@@ -236,24 +233,23 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsInvalidRiskTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, authorizationToken) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -263,40 +259,35 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
 
     fun submitPayment(consentRequest: OBWriteDomesticScheduledConsent4): OBWriteDomesticScheduledResponse5 {
         val (consent, authorizationToken) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
+                consentRequest
         )
         return submitPayment(consent, authorizationToken)
     }
 
     fun submitPayment(
-        consentResponse: OBWriteDomesticScheduledConsentResponse5,
-        authorizationToken: AccessToken
+            consentResponse: OBWriteDomesticScheduledConsentResponse5,
+            authorizationToken: AccessToken
     ): OBWriteDomesticScheduledResponse5 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        return submitPaymentForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
-        return createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
-    }
-
-    private fun submitPaymentForPatchedConsent(
-        patchedConsent: OBWriteDomesticScheduledConsentResponse5,
-        authorizationToken: AccessToken
+    private fun submitPaymentForConsent(
+            consentResponse: OBWriteDomesticScheduledConsentResponse5,
+            authorizationToken: AccessToken
     ): OBWriteDomesticScheduledResponse5 {
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
         return paymentApiClient.submitPayment(
-            createPaymentUrl,
-            authorizationToken,
-            paymentSubmissionRequest
+                createPaymentUrl,
+                authorizationToken,
+                paymentSubmissionRequest
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduled2 {
+    private fun createPaymentRequest(consentResponse: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduled2 {
         return OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.copyOBWriteDomesticScheduled2DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+                OBWriteDomesticScheduled2Data()
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteDomesticScheduled2DataInitiation(consentResponse.data.initiation))
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -268,18 +268,4 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         )
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            paymentLinks.GetDomesticScheduledPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
@@ -18,47 +18,28 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
     fun shouldGetDomesticScheduledPaymentsConsentsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val consent = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
-
+        val consentResponse = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 
     fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccountTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
         consentRequest.data.initiation.debtorAccount(null)
-        val consent = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.debtorAccount).isNull()
-
-        // When
-        val result = createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
-
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
-        assertThat(result.data.initiation.debtorAccount).isNull()
+        val consentResponse = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsent(consentRequest)
+
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.debtorAccount).isNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -18,7 +18,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standi
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBRisk1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
@@ -61,24 +60,23 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitStandingOrderForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+        submitStandingOrderForConsent(consentResponse, accessTokenAuthorizationCode)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitStandingOrderForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+            submitStandingOrderForConsent(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -90,16 +88,16 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -120,16 +118,16 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -150,16 +148,16 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -180,16 +178,16 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -210,20 +208,19 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val standingOrderSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val standingOrderSubmissionRequest = createStandingOrderRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val standingOrderSubmissionRequestWithInvalidConsentId = createStandingOrderRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val standingOrderSubmissionRequestWithInvalidConsentId = createStandingOrderRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
             defaultMapper.writeValueAsString(standingOrderSubmissionRequestWithInvalidConsentId)
@@ -248,20 +245,19 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
-        patchedConsent.data.initiation.firstPaymentAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = createStandingOrderRequest(patchedConsent)
+        consentResponse.data.initiation.firstPaymentAmount.amount = "123123"
+        val paymentSubmissionInvalidAmount = createStandingOrderRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
             defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
@@ -286,24 +282,23 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, authorizationToken) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit standing order
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitStandingOrderForPatchedConsent(patchedConsent, authorizationToken)
+            submitStandingOrderForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -322,19 +317,14 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         consentResponse: OBWriteDomesticStandingOrderConsentResponse6,
         authorizationToken: AccessToken
     ): OBWriteDomesticStandingOrderResponse6 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitStandingOrderForPatchedConsent(patchedConsent, authorizationToken)
+        return submitStandingOrderForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteDomesticStandingOrderConsentResponse6): OBWriteDomesticStandingOrderConsentResponse6 {
-        return createDomesticStandingOrderConsentsApi.getPatchedConsent(consent)
-    }
-
-    private fun submitStandingOrderForPatchedConsent(
-        patchedConsent: OBWriteDomesticStandingOrderConsentResponse6,
-        authorizationToken: AccessToken
+    private fun submitStandingOrderForConsent(
+            consentResponse: OBWriteDomesticStandingOrderConsentResponse6,
+            authorizationToken: AccessToken
     ): OBWriteDomesticStandingOrderResponse6 {
-        val paymentSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
         return paymentApiClient.submitPayment(
             createPaymentUrl,
             authorizationToken,
@@ -351,10 +341,6 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
                         patchedConsent.data.initiation
                     )
                 )
-        ).risk(
-            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
-                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
-                .paymentContextCode(patchedConsent.risk.paymentContextCode)
-        )
+        ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -292,18 +292,4 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         )
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteDomesticStandingOrderConsentResponse6): OBWriteDomesticStandingOrderConsentResponse6 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            paymentLinks.GetDomesticStandingOrderConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
@@ -18,23 +18,14 @@ class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val consent =
-            createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createDomesticStandingOrderConsentsApi.getPatchedConsent(consent)
-
+        val consentResponse =
+            createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
@@ -41,16 +41,10 @@ class CreateDomesticVrpConsents(val version: OBVersion, val tppResource: CreateT
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
         populateDebtorAccount(consentRequest)
-        val consent = createDomesticVrpConsent(consentRequest)
+        val consentResponse = createDomesticVrpConsent(consentRequest)
 
         // When
-        deleteConsent(consent.data.consentId)
-        // Verify we cannot get the consent anymore
-        val error = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            getPatchedConsent(consent)
-        }
-        // then
-        assertThat(error.message).matchesPredicate { msg -> msg!!.contains("\"ErrorCode\":\"UK.OBIE.NotFound\",\"Message\":\"Resource not found\"") }
+        deleteConsent(consentResponse.data.consentId)
     }
 
     fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest() {
@@ -265,20 +259,6 @@ class CreateDomesticVrpConsents(val version: OBVersion, val tppResource: CreateT
             "Rejected"
         )
         return consent to accessTokenAuthorizationCode
-    }
-
-    fun getPatchedConsent(consent: OBDomesticVRPConsentResponse): OBDomesticVRPConsentResponse {
-        val patchedConsent = paymentApiClient.getConsent<OBDomesticVRPConsentResponse>(
-            paymentLinks.GetDomesticVRPConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
     }
 
     private fun populateDebtorAccount(consentRequest: OBDomesticVRPConsentRequest) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsents.kt
@@ -23,24 +23,14 @@ class GetDomesticVrpConsents(
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
         populateDebtorAccount(consentRequest)
-
-        val consent = createDomesticVrpConsents.createDomesticVrpConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createDomesticVrpConsents.getPatchedConsent(consent)
-
+        val consentResponse = createDomesticVrpConsents.createDomesticVrpConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 
     private fun populateDebtorAccount(consentRequest: OBDomesticVRPConsentRequest){

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
@@ -28,8 +28,8 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
 
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
         // When
         val result = submitFilePayment(consentRequest)
@@ -47,8 +47,8 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
 
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithMandatoryFieldsAndFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
         // When
         val result = submitFilePayment(consentRequest)
@@ -70,28 +70,27 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitFilePaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+        submitFilePaymentForConsent(consentResponse, accessTokenAuthorizationCode)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitFilePaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+            submitFilePaymentForConsent(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -103,29 +102,29 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                paymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    paymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -137,29 +136,29 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                paymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    paymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(null).sendRequest()
+                    .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -171,29 +170,29 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                paymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    paymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
+                    .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -205,29 +204,29 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createFilePaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                paymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    paymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
+                    .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -239,37 +238,36 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val filePaymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+        val filePaymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val filePaymentSubmissionRequestWithInvalidConsentId = createFilePaymentRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val filePaymentSubmissionRequestWithInvalidConsentId = createFilePaymentRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(filePaymentSubmissionRequestWithInvalidConsentId)
+                defaultMapper.writeValueAsString(filePaymentSubmissionRequestWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                filePaymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    filePaymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -281,37 +279,36 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
         // Given
         val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
-            fileContent,
-            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+                fileContent,
+                PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
 
-        val (consent, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessTokenAuthorizationCode) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
 
-        patchedConsent.data.initiation.controlSum = BigDecimal("123123")
-        val paymentSubmissionInvalidAmount = createFilePaymentRequest(patchedConsent)
+        consentResponse.data.initiation.controlSum = BigDecimal("123123")
+        val paymentSubmissionInvalidAmount = createFilePaymentRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
+                defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(
-                createPaymentUrl,
-                accessTokenAuthorizationCode,
-                paymentSubmissionRequest
+                    createPaymentUrl,
+                    accessTokenAuthorizationCode,
+                    paymentSubmissionRequest
             )
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
@@ -320,41 +317,36 @@ class CreateFilePayment(val version: OBVersion, val tppResource: CreateTppCallba
     }
 
     fun submitFilePayment(consentRequest: OBWriteFileConsent3): OBWriteFileResponse3 {
-        val (consent, authorizationToken) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createFilePaymentConsentsApi.createFilePaymentConsentAndAuthorize(
+                consentRequest
         )
-        return submitFilePayment(consent, authorizationToken)
+        return submitFilePayment(consentResponse, authorizationToken)
     }
 
     private fun submitFilePayment(
-        consentResponse: OBWriteFileConsentResponse4,
-        authorizationToken: AccessToken
+            consentResponse: OBWriteFileConsentResponse4,
+            authorizationToken: AccessToken
     ): OBWriteFileResponse3 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitFilePaymentForPatchedConsent(patchedConsent, authorizationToken)
+        return submitFilePaymentForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteFileConsentResponse4): OBWriteFileConsentResponse4 {
-        return createFilePaymentConsentsApi.getPatchedConsent(consent)
-    }
-
-    private fun submitFilePaymentForPatchedConsent(
-        patchedConsent: OBWriteFileConsentResponse4,
-        authorizationToken: AccessToken
+    private fun submitFilePaymentForConsent(
+            consentResponse: OBWriteFileConsentResponse4,
+            authorizationToken: AccessToken
     ): OBWriteFileResponse3 {
-        val paymentSubmissionRequest = createFilePaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createFilePaymentRequest(consentResponse)
         return paymentApiClient.submitPayment(
-            createPaymentUrl,
-            authorizationToken,
-            paymentSubmissionRequest
+                createPaymentUrl,
+                authorizationToken,
+                paymentSubmissionRequest
         )
     }
 
-    private fun createFilePaymentRequest(patchedConsent: OBWriteFileConsentResponse4): OBWriteFile2 {
+    private fun createFilePaymentRequest(consentResponse: OBWriteFileConsentResponse4): OBWriteFile2 {
         return OBWriteFile2().data(
-            OBWriteFile2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteFileConsentResponse4DataInitiationToOBWriteFile2DataInitiation(patchedConsent.data.initiation))
+                OBWriteFile2Data()
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(mapOBWriteFileConsentResponse4DataInitiationToOBWriteFile2DataInitiation(consentResponse.data.initiation))
         )
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -380,17 +380,4 @@ class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: Create
         return consent to accessTokenAuthorizationCode
     }
 
-    fun getPatchedConsent(consent: OBWriteFileConsentResponse4): OBWriteFileConsentResponse4 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteFileConsentResponse4>(
-            paymentLinks.GetFilePaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
-
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
@@ -24,23 +24,13 @@ class GetFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTpp
             fileContent,
             PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
-        val consent = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
         // When
-        val result = createFilePaymentsConsentsApi.getPatchedConsent(consent)
-
+        val consentResponse = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.data.initiation.fileHash).isEqualTo(consent.data.initiation.fileHash)
-        assertThat(result.data.initiation.fileReference).isEqualTo(consent.data.initiation.fileReference)
-        assertThat(result.data.initiation.fileType).isEqualTo(consent.data.initiation.fileType)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
     }
 
     fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest() {
@@ -51,23 +41,14 @@ class GetFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTpp
             PaymentFileType.UK_OBIE_PAIN_001_001_008.type
         )
         consentRequest.data.initiation.debtorAccount(null)
-
-        val consent = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.data.initiation.debtorAccount).isNull()
-
-        // When
-        val result = createFilePaymentsConsentsApi.getPatchedConsent(consent)
-
+        // when
+        val consentResponse = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.data.initiation.debtorAccount).isNull()
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.initiation.debtorAccount).isNull()
     }
 
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -114,24 +114,23 @@ class CreateInternationalPayment(
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
 
-        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        submitPaymentForConsent(consentResponse, authorizationToken)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -142,16 +141,16 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -167,16 +166,16 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -191,16 +190,16 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -216,16 +215,16 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -241,20 +240,19 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
                 defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
@@ -273,23 +271,22 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         val paymentSubmissionInvalidAmount = OBWriteInternational3().data(
                 OBWriteInternational3Data()
-                        .consentId(patchedConsent.data.consentId)
-                        .initiation(PaymentFactory.copyOBWriteInternational3DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteInternational3DataInitiation(consentResponse.data.initiation))
+        ).risk(consentResponse.risk)
         paymentSubmissionInvalidAmount.data.initiation.instructedAmount =
                 OBWriteDomestic2DataInitiationInstructedAmount().amount("123123").currency("GBP")
 
@@ -311,24 +308,23 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayments_throwsInvalidRiskTest() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -337,29 +333,24 @@ class CreateInternationalPayment(
     }
 
     fun submitPayment(consentRequest: OBWriteInternationalConsent5): OBWriteInternationalResponse5 {
-        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
                 consentRequest
         )
-        return submitPayment(consent, authorizationToken)
+        return submitPayment(consentResponse, authorizationToken)
     }
 
     fun submitPayment(
             consentResponse: OBWriteInternationalConsentResponse6,
             authorizationToken: AccessToken
     ): OBWriteInternationalResponse5 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        return submitPaymentForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteInternationalConsentResponse6): OBWriteInternationalConsentResponse6 {
-        return createInternationalPaymentsConsents.getPatchedConsent(consent)
-    }
-
-    private fun submitPaymentForPatchedConsent(
-            patchedConsent: OBWriteInternationalConsentResponse6,
+    private fun submitPaymentForConsent(
+            consentResponse: OBWriteInternationalConsentResponse6,
             authorizationToken: AccessToken
     ): OBWriteInternationalResponse5 {
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
         return paymentApiClient.submitPayment(
                 createPaymentUrl,
                 authorizationToken,
@@ -367,11 +358,11 @@ class CreateInternationalPayment(
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteInternationalConsentResponse6): OBWriteInternational3 {
+    private fun createPaymentRequest(consentResponse: OBWriteInternationalConsentResponse6): OBWriteInternational3 {
         return OBWriteInternational3().data(
                 OBWriteInternational3Data()
-                        .consentId(patchedConsent.data.consentId)
-                        .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(consentResponse.data.initiation)
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -268,18 +268,4 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         )
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteInternationalConsentResponse6): OBWriteInternationalConsentResponse6 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteInternationalConsentResponse6>(
-            paymentLinks.GetInternationalPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -132,7 +132,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
-        val (consent, _) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, _) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -141,7 +141,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            getFundsConfirmation(consent, accessTokenClientCredentials)
+            getFundsConfirmation(consentResponse, accessTokenClientCredentials)
         }
 
         // Then
@@ -153,11 +153,11 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
             consentRequest
         )
-        val patchedConsent = createInternationalPaymentsConsents.getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         val payment: OBWriteInternationalResponse5 = paymentApiClient.submitPayment(
             paymentLinks.CreateInternationalPayment,
@@ -170,7 +170,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            getFundsConfirmation(consent, accessTokenAuthorizationCode)
+            getFundsConfirmation(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -179,10 +179,10 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     }
 
     private fun createConsentAndGetFundsConfirmation(consentRequest: OBWriteInternationalConsent5): OBWriteFundsConfirmationResponse1 {
-        val (consent, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
             consentRequest
         )
-        return getFundsConfirmation(consent, accessTokenAuthorizationCode)
+        return getFundsConfirmation(consentResponse, accessTokenAuthorizationCode)
     }
 
     private fun getFundsConfirmation(
@@ -197,11 +197,11 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteInternationalConsentResponse6): OBWriteInternational3 {
+    private fun createPaymentRequest(consentResponse: OBWriteInternationalConsentResponse6): OBWriteInternational3 {
         return OBWriteInternational3().data(
             OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+                .consentId(consentResponse.data.consentId)
+                .initiation(consentResponse.data.initiation)
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
@@ -23,25 +23,15 @@ class GetInternationalPaymentsConsents(
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-
-        val consent = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-
         // When
-        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
-
+        val consentResponse = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
     }
 
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_Test() {
@@ -50,24 +40,14 @@ class GetInternationalPaymentsConsents(
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.ACTUAL
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
-
-        val consent = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
-
+        val consentResponse = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_Test() {
@@ -76,23 +56,13 @@ class GetInternationalPaymentsConsents(
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.INDICATIVE
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
-
-        val consent = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
-
+        val consentResponse = createInternationalPaymentsConsents.createInternationalPaymentConsent(consentRequest)
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -18,7 +18,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.s
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBRisk1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
@@ -26,7 +25,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConse
 class CreateInternationalScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createInternationalScheduledPaymentsConsents =
-        CreateInternationalScheduledPaymentsConsents(version, tppResource)
+            CreateInternationalScheduledPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
     private val createPaymentUrl = paymentLinks.CreateInternationalScheduledPayment
     private val paymentApiClient = tppResource.tpp.paymentApiClient
@@ -34,7 +33,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun createInternationalScheduledPayment_rateType_AGREED_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
 
         // When
@@ -54,7 +53,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun createInternationalScheduledPayment_rateType_ACTUAL_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.ACTUAL
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
@@ -77,7 +76,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun createInternationalScheduledPayment_rateType_INDICATIVE_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.INDICATIVE
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
@@ -117,25 +116,24 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
-        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+        val (consentResponse, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        submitPaymentForConsent(consentResponse, authorizationToken)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -146,23 +144,23 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -173,23 +171,23 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(null).sendRequest()
+                    .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -200,23 +198,23 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
+                    .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -227,23 +225,23 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
+                    .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -254,30 +252,29 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
+                defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -288,31 +285,30 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
-        patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = createPaymentRequest(patchedConsent)
+        consentResponse.data.initiation.instructedAmount.amount = "123123"
+        val paymentSubmissionInvalidAmount = createPaymentRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
+                defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
+                    .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
@@ -323,24 +319,23 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest() {
         // Given
         val consentRequest = OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
-        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+            submitPaymentForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -349,49 +344,40 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     }
 
     fun submitPayment(consentRequest: OBWriteInternationalScheduledConsent5): OBWriteInternationalScheduledResponse5 {
-        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
-            consentRequest
+        val (consentResponse, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
         )
-        return submitPayment(consent, authorizationToken)
+        return submitPayment(consentResponse, authorizationToken)
     }
 
     fun submitPayment(
-        consentResponse: OBWriteInternationalScheduledConsentResponse6,
-        authorizationToken: AccessToken
+            consentResponse: OBWriteInternationalScheduledConsentResponse6,
+            authorizationToken: AccessToken
     ): OBWriteInternationalScheduledResponse5 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+        return submitPaymentForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduledConsentResponse6 {
-        return createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
-    }
-
-    private fun submitPaymentForPatchedConsent(
-        patchedConsent: OBWriteInternationalScheduledConsentResponse6,
-        authorizationToken: AccessToken
+    private fun submitPaymentForConsent(
+            consentResponse: OBWriteInternationalScheduledConsentResponse6,
+            authorizationToken: AccessToken
     ): OBWriteInternationalScheduledResponse5 {
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
         return paymentApiClient.submitPayment(
-            createPaymentUrl,
-            authorizationToken,
-            paymentSubmissionRequest
+                createPaymentUrl,
+                authorizationToken,
+                paymentSubmissionRequest
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduled3 {
+    private fun createPaymentRequest(consentResponse: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduled3 {
         return OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(
-            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
-                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
-                .paymentContextCode(patchedConsent.risk.paymentContextCode)
-        )
+                OBWriteInternationalScheduled3Data()
+                        .consentId(consentResponse.data.consentId)
+                        .initiation(
+                                mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
+                                        consentResponse.data.initiation
+                                )
+                        )
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -297,18 +297,4 @@ class CreateInternationalScheduledPaymentsConsents(
 
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduledConsentResponse6 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            paymentLinks.GetInternationalScheduledPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
@@ -154,11 +154,11 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
     fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent5()
-        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-        val patchedConsent = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+
+        val paymentSubmissionRequest = createPaymentRequest(consentResponse)
 
         val payment: OBWriteInternationalScheduledResponse5 = paymentApiClient.submitPayment(
             paymentLinks.CreateInternationalScheduledPayment,
@@ -171,7 +171,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            getFundsConfirmation(consent, authorizationToken)
+            getFundsConfirmation(consentResponse, authorizationToken)
         }
 
         // Then
@@ -198,19 +198,15 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         )
     }
 
-    private fun createPaymentRequest(patchedConsent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduled3 {
+    private fun createPaymentRequest(consentResponse: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduled3 {
         return OBWriteInternationalScheduled3().data(
             OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
+                .consentId(consentResponse.data.consentId)
                 .initiation(
                     PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
+                            consentResponse.data.initiation
                     )
                 )
-        ).risk(
-            OBRisk1().merchantCustomerIdentification(patchedConsent.risk.merchantCustomerIdentification)
-                .merchantCategoryCode(patchedConsent.risk.merchantCategoryCode)
-                .paymentContextCode(patchedConsent.risk.paymentContextCode)
-        )
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
@@ -10,74 +10,63 @@ import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 
 class GetInternationalScheduledPaymentsConsents(
-    val version: OBVersion,
-    val tppResource: CreateTppCallback.TppResource
+        val version: OBVersion,
+        val tppResource: CreateTppCallback.TppResource
 ) {
     private val createInternationalScheduledPaymentsConsents =
-        CreateInternationalScheduledPaymentsConsents(version, tppResource)
+            CreateInternationalScheduledPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-
-        val consent =
-            createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
-
         // When
-        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
+        val consentResponse =
+                createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.exchangeRateInformation.rateType).isEqualTo(OBExchangeRateType2Code.AGREED)
     }
 
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.ACTUAL
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
-
-        val consent =
-            createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
-
         // When
-        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
+        val consentResponse =
+                createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.exchangeRateInformation.rateType).isEqualTo(OBExchangeRateType2Code.ACTUAL)
     }
 
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_Test() {
         // Given
         val consentRequest =
-            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+                OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.INDICATIVE
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val consent =
-            createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
-
         // When
-        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
+        val consentResponse =
+                createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.risk).isNotNull()
+        assertThat(consentResponse.data.initiation.exchangeRateInformation.rateType).isEqualTo(OBExchangeRateType2Code.INDICATIVE)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
@@ -60,24 +60,23 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
         // Submit first payment
-        submitStandingOrderForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+        submitStandingOrderForConsent(consentResponse, accessTokenAuthorizationCode)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             // Verify we fail to submit a second payment
-            submitStandingOrderForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
+            submitStandingOrderForConsent(consentResponse, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -89,16 +88,16 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -119,16 +118,16 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -149,16 +148,16 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -179,16 +178,16 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -209,20 +208,19 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val standingOrderSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val standingOrderSubmissionRequest = createStandingOrderRequest(consentResponse)
 
-        patchedConsent.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
-        val standingOrderSubmissionRequestWithInvalidConsentId = createStandingOrderRequest(patchedConsent)
+        consentResponse.data.consentId = com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
+        val standingOrderSubmissionRequestWithInvalidConsentId = createStandingOrderRequest(consentResponse)
 
         val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
             defaultMapper.writeValueAsString(standingOrderSubmissionRequestWithInvalidConsentId)
@@ -247,20 +245,19 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, accessTokenAuthorizationCode) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
 
-        patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = createStandingOrderRequest(patchedConsent)
+        consentResponse.data.initiation.instructedAmount.amount = "123123"
+        val paymentSubmissionInvalidAmount = createStandingOrderRequest(consentResponse)
 
         val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
             defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
@@ -285,24 +282,23 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val (consent, authorizationToken) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
-        val patchedConsent = getPatchedConsent(consent)
 
         // Alter Risk Merchant
-        patchedConsent.risk.merchantCategoryCode = "wrongMerchant"
+        consentResponse.risk.merchantCategoryCode = "wrongMerchant"
 
         // Submit standing order
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            submitStandingOrderForPatchedConsent(patchedConsent, authorizationToken)
+            submitStandingOrderForConsent(consentResponse, authorizationToken)
         }
 
         // Then
@@ -311,29 +307,24 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
     }
 
     fun submitStandingOrder(consentRequest: OBWriteInternationalStandingOrderConsent6): OBWriteInternationalStandingOrderResponse7 {
-        val (consent, authorizationToken) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
+        val (consentResponse, authorizationToken) = createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsentAndAuthorize(
             consentRequest
         )
-        return submitStandingOrder(consent, authorizationToken)
+        return submitStandingOrder(consentResponse, authorizationToken)
     }
 
     fun submitStandingOrder(
         consentResponse: OBWriteInternationalStandingOrderConsentResponse7,
         authorizationToken: AccessToken
     ): OBWriteInternationalStandingOrderResponse7 {
-        val patchedConsent = getPatchedConsent(consentResponse)
-        return submitStandingOrderForPatchedConsent(patchedConsent, authorizationToken)
+        return submitStandingOrderForConsent(consentResponse, authorizationToken)
     }
 
-    private fun getPatchedConsent(consent: OBWriteInternationalStandingOrderConsentResponse7): OBWriteInternationalStandingOrderConsentResponse7 {
-        return createInternationalStandingOrderConsentsApi.getPatchedConsent(consent)
-    }
-
-    private fun submitStandingOrderForPatchedConsent(
-        patchedConsent: OBWriteInternationalStandingOrderConsentResponse7,
+    private fun submitStandingOrderForConsent(
+        consentResponse: OBWriteInternationalStandingOrderConsentResponse7,
         authorizationToken: AccessToken
     ): OBWriteInternationalStandingOrderResponse7 {
-        val paymentSubmissionRequest = createStandingOrderRequest(patchedConsent)
+        val paymentSubmissionRequest = createStandingOrderRequest(consentResponse)
         return paymentApiClient.submitPayment(
             createPaymentUrl,
             authorizationToken,
@@ -341,15 +332,15 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         )
     }
 
-    private fun createStandingOrderRequest(patchedConsent: OBWriteInternationalStandingOrderConsentResponse7): OBWriteInternationalStandingOrder4 {
+    private fun createStandingOrderRequest(consentResponse: OBWriteInternationalStandingOrderConsentResponse7): OBWriteInternationalStandingOrder4 {
         return OBWriteInternationalStandingOrder4().data(
             OBWriteInternationalStandingOrder4Data()
-                .consentId(patchedConsent.data.consentId)
+                .consentId(consentResponse.data.consentId)
                 .initiation(
                     mapOBWriteInternationalStandingOrderConsentResponse7DataInitiationToOBWriteInternationalStandingOrder3DataInitiation(
-                        patchedConsent.data.initiation
+                            consentResponse.data.initiation
                     )
                 )
-        ).risk(patchedConsent.risk)
+        ).risk(consentResponse.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
@@ -290,18 +290,4 @@ class CreateInternationalStandingOrderConsents(val version: OBVersion, val tppRe
         )
         return consent to accessTokenAuthorizationCode
     }
-
-    fun getPatchedConsent(consent: OBWriteInternationalStandingOrderConsentResponse7): OBWriteInternationalStandingOrderConsentResponse7 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteInternationalStandingOrderConsentResponse7>(
-            paymentLinks.GetInternationalStandingOrderConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
-    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/GetInternationalStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/GetInternationalStandingOrderConsents.kt
@@ -18,23 +18,14 @@ class GetInternationalStandingOrderConsents(val version: OBVersion, val tppResou
         // Given
         val consentRequest =
             OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6()
-        val consent =
+        // When
+        val consentResponse =
             createInternationalStandingOrderConsentsApi.createInternationalStandingOrderConsent(consentRequest)
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // When
-        val result = createInternationalStandingOrderConsentsApi.getPatchedConsent(consent)
-
-        // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.risk).isNotNull()
-        assertThat(result.data).isEqualTo(consent.data)
-        assertThat(result.risk).isEqualTo(consent.risk)
+        assertThat(consentResponse).isNotNull()
+        assertThat(consentResponse.data).isNotNull()
+        assertThat(consentResponse.data.consentId).isNotEmpty()
+        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.risk).isNotNull()
     }
 }


### PR DESCRIPTION
- Deleted all uses of get Patched consent to use the consent response after creation
- Fix test fails

Issue: https://github.com/secureapigateway/secureapigateway/issues/947