### PR TITLE
940: Tpps not being unregistered by functional tests

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
@@ -95,7 +95,7 @@ data class Tpp(
 
 
     fun unregister(): Triple<Request, Response, Result<String, FuelError>> {
-        return unregisterTpp(registrationResponse.client_id)
+        return unregisterTpp(registrationResponse.client_id, registrationResponse.registration_access_token)
     }
 
     private fun signRegistrationRequest(registrationRequest: RegistrationRequest): String {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentApiClient.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentApiClient.kt
@@ -6,7 +6,6 @@ import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
 import com.forgerock.sapi.gateway.ob.uk.support.account.HTTP_STATUS_CODE_NO_CONTENT
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.asDiscovery
-import com.forgerock.sapi.gateway.ob.uk.support.discovery.rsDiscovery
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBConstants
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.Headers
@@ -98,7 +97,6 @@ class PaymentApiClient(val tpp: Tpp) {
                     result.component2()
                 )
             }
-
             if (response.header("x-jws-signature").isNullOrEmpty()) {
                 throw AssertionError(
                     "The response should have 'x-jws-signature' header for the consent : ${result.get()}"

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/registration/Registration.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/registration/Registration.kt
@@ -13,6 +13,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Headers
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.result.Result
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
@@ -24,8 +25,10 @@ data class UserRegistrationRequest(val user: User) {
 
 data class User(val userName: String, val password: String, var uid: String?)
 
-fun unregisterTpp(id: String): Triple<Request, Response, Result<String, FuelError>> {
+fun unregisterTpp(id: String, registrationAccessToken: String): Triple<Request, Response, Result<String, FuelError>> {
     return Fuel.delete("${asDiscovery.registration_endpoint!!}/$id")
+        .authentication()
+        .bearer(registrationAccessToken)
         .responseObject()
 }
 


### PR DESCRIPTION
Found while trying to work out why nightly was failing tests (because of the issue 940)

Issue: https://github.com/secureapigateway/secureapigateway/issues/940