### PR TITLE
960: Output x-fapi-interaction-id if call fails

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentApiClient.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentApiClient.kt
@@ -91,12 +91,20 @@ class PaymentApiClient(val tpp: Tpp) {
             val (_, response, result) = request.responseObject<T>()
 
             if (!response.isSuccessful) {
+                var fapiInteractionId = "no id"
+                val fapiInteractionIdHeaderVals = response.headers.get("x-fapi-interaction-id");
+                if(fapiInteractionIdHeaderVals.isNotEmpty()){
+                    fapiInteractionId = fapiInteractionIdHeaderVals.first()
+                }
+
                 throw AssertionError(
                     "API call: " + request.method + " " + request.url + " returned an error response:\n"
-                            + result.component2()?.errorData?.toString(Charsets.UTF_8),
+                            + result.component2()?.errorData?.toString(Charsets.UTF_8) + "\n x-fapi-interaction-id: "
+                            + fapiInteractionId,
                     result.component2()
                 )
             }
+
             if (response.header("x-jws-signature").isNullOrEmpty()) {
                 throw AssertionError(
                     "The response should have 'x-jws-signature' header for the consent : ${result.get()}"


### PR DESCRIPTION
When a call to the SAPIG fails we now output the x-fapi-interaction-id value so that a failing request can be correlated with the logs of the SAPIG under test. 

Issue: https://github.com/secureapigateway/secureapigateway/issues/960