### PR TITLE
955: initiation consent section match with initiation payment section

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -49,9 +49,11 @@ class CreateDomesticPayment(
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
         assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+
+        consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
+            .amount("123123")
+            .currency("EUR")
+
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             submitPaymentForConsent(consentResponse.data.consentId, consentRequest, authorizationToken)

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -17,7 +17,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.schedu
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
@@ -77,9 +76,9 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+        consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
+            .amount("123123")
+            .currency("EUR")
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             submitPaymentForConsent(consentResponse.data.consentId, consentRequest, accessTokenAuthorizationCode)

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -80,9 +80,9 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         assertThat(consentResponse.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+        consentRequest.data.initiation.recurringPaymentAmount = OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount()
+            .amount("123123")
+            .currency("EUR")
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -147,9 +147,9 @@ class CreateInternationalPayment(
         assertThat(consentResponse.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+        consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
+            .amount("123123")
+            .currency("EUR")
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -59,9 +59,9 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         assertThat(consentResponse.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+        consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
+            .amount("123123")
+            .currency("EUR")
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
@@ -56,9 +56,9 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         assertThat(consentResponse.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
-        val supplementaryData1 = OBSupplementaryData1()
-        supplementaryData1.data = "{\"value\":\"initiation validation must fails\"}"
-        consentRequest.data.initiation.supplementaryData = supplementaryData1
+        consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
+            .amount("123123")
+            .currency("EUR")
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {


### PR DESCRIPTION
- Improve current negative test to validate initiation
Issue: https://github.com/secureapigateway/secureapigateway/issues/955