### PR TITLE
969: prepare SAPIG release 1.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,9 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
  */
 // project version
 // pom artifact version used when the built artifact is published
-version = "1.0.0"
+version = "1.0.2"
 // Test jar library version used in the task 'generateTestJar'
-val release = "1.0.0"
+val release = "1.0.2"
 val jaxbVersion = "2.2.11"
 
 plugins {
@@ -75,7 +75,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:1.0.1"))
+    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:1.0.2"))
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-shared")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel")


### PR DESCRIPTION
- Bumped commons 1.0.2
- Updated version to 1.0.2
- Updated Fuel initialiser to normalize the deserialiser and serialiser of date times 
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/969