### PR TITLE
983: Adding VRP Test to check that payments fail if the maxIndividualAmount control param is breached

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -148,4 +148,15 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     fun shouldCreateDomesticVrp_throwsPolicyValidationErrorConsent_v3_1_10() {
         createDomesticVrpPayment.shouldCreateDomesticVrp_throwsPolicyValidationErrorTest()
     }
+
+    @EnabledIfVersion(
+            type = "payments",
+            apiVersion = "v3.1.10",
+            operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+            apis = ["domestic-vrps", "domestic-vrp-consents"]
+    )
+    @Test
+    fun shouldFailToCreateVrpWhenMaxIndividualAmountBreachedTest_v3_1_10() {
+        createDomesticVrpPayment.shouldFailToCreateVrpWhenMaxIndividualAmountBreachedTest()
+    }
 }


### PR DESCRIPTION
Adding test CreateDomesticVrpTest.shouldFailToCreateVrpWhenMaxIndividualAmountBreachedTest_v3_1_10

This test asserts that an error is returned when attempting to create a VRP payment with an instructed payment amount > maxIndividualAmount control param

https://github.com/SecureApiGateway/SecureApiGateway/issues/983