### PR TITLE
980: Fixing assertions for International Payments tests which use consents with only mandatory fields

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -124,14 +124,20 @@ class CreateInternationalPayment(
             OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields()
 
         // When
-        val result = submitPayment(consentRequest)
+        val (consentResponse, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+                consentRequest
+        )
+        val result =  submitPayment(consentResponse.data.consentId, consentRequest, authorizationToken)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
-        assertThat(result.data.exchangeRateInformation).isNull()
+        assertThat(result.data.exchangeRateInformation).isNotNull()
+        assertThat(result.data.exchangeRateInformation.exchangeRate).isEqualTo(consentResponse.data.exchangeRateInformation.exchangeRate)
+        assertThat(result.data.exchangeRateInformation.rateType).isEqualTo(consentResponse.data.exchangeRateInformation.rateType)
+        assertThat(result.data.exchangeRateInformation.unitCurrency).isEqualTo(consentResponse.data.exchangeRateInformation.unitCurrency)
     }
 
     fun shouldCreateInternationalPayment_throwsInvalidInitiation_Test() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -153,14 +153,20 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest = aValidOBWriteInternationalScheduledConsent5MandatoryFields()
 
         // When
-        val result = submitPayment(consentRequest)
+        val (consentResponse, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+                consentRequest
+        )
+        val result = submitPayment(consentResponse.data.consentId, consentRequest, authorizationToken)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
-        assertThat(result.data.exchangeRateInformation).isNull()
+        assertThat(result.data.exchangeRateInformation).isNotNull()
+        assertThat(result.data.exchangeRateInformation.exchangeRate).isEqualTo(consentResponse.data.exchangeRateInformation.exchangeRate)
+        assertThat(result.data.exchangeRateInformation.rateType).isEqualTo(consentResponse.data.exchangeRateInformation.rateType)
+        assertThat(result.data.exchangeRateInformation.unitCurrency).isEqualTo(consentResponse.data.exchangeRateInformation.unitCurrency)
     }
 
     fun shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_Test() {


### PR DESCRIPTION
A bug fix has been applied to fix International Payments Consents and International Scheduled Payments Consents to generated exchangeRateInformation in the response when it is not provided in the request.

Fixing assertions in tests which created payments for such consents to validate the exchangeRateInformation block in the payment response matches the consent response

https://github.com/SecureApiGateway/SecureApiGateway/issues/980