### PR TITLE
578: Fixing test data to be compatible with OBIE schema validation rules

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -11,7 +11,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.paymen
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
@@ -296,7 +295,7 @@ class CreateDomesticPayment(
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -320,7 +320,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -12,12 +12,10 @@ import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.*
-import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory.Companion.mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
@@ -353,7 +351,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit standing order
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -1,5 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
@@ -72,7 +73,7 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
         assertThat(consentResponse2.risk).isNotNull()
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
     }
 
     fun createDomesticStandingOrdersConsents_NoIdempotencyKey_throwsBadRequestTest() {
@@ -169,7 +170,10 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
 
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
-        assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_FREQUENCY_VALUE)
+        assertThat(exception.message.toString()).all {
+            contains("ErrorCode\":\"UK.OBIE.Field.Invalid\"")
+            contains("Path\":\"data.initiation.frequency\"")
+        }
     }
 
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJwsTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -394,15 +394,19 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
     ): OBDomesticVRPRequest {
         return OBDomesticVRPRequest().data(
             OBDomesticVRPRequestData()
-                .consentId(consentId)
-                .initiation(PaymentFactory.copyOBDomesticVRPInitiation(consentRequest.data.initiation))
-                .instruction(buildVrpInstruction(consentRequest))
+                    .consentId(consentId)
+                    .initiation(PaymentFactory.copyOBDomesticVRPInitiation(consentRequest.data.initiation))
+                    .instruction(buildVrpInstruction(consentRequest))
+                    .psUAuthenticationMethod(consentRequest.data.controlParameters.psUAuthenticationMethods.first())
         ).risk(consentRequest.risk)
     }
 
     private fun buildVrpInstruction(consentRequest: OBDomesticVRPConsentRequest): OBDomesticVRPInstruction? {
         val instruction = OBDomesticVRPInstruction().creditorAccount(consentRequest.data.initiation.creditorAccount)
-            .instructedAmount(consentRequest.data.controlParameters.maximumIndividualAmount);
+                                                    .instructedAmount(consentRequest.data.controlParameters.maximumIndividualAmount)
+                                                    .instructionIdentification(System.nanoTime().toString())
+                                                    .endToEndIdentification(System.nanoTime().toString())
+
         if (consentRequest.data.initiation.creditorPostalAddress != null) {
             instruction.creditorPostalAddress = consentRequest.data.initiation.creditorPostalAddress
         }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -13,7 +13,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.p
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
@@ -379,7 +378,7 @@ class CreateInternationalPayment(
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -13,7 +13,6 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.s
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
@@ -392,7 +391,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit payment
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
@@ -12,12 +12,10 @@ import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.*
-import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory.Companion.mapOBWriteInternationalStandingOrderConsentResponse7DataInitiationToOBWriteInternationalStandingOrder3DataInitiation
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.standing.orders.consents.api.v3_1_8.CreateInternationalStandingOrderConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory
 
@@ -353,7 +351,7 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         // When
 
         // Alter Risk Merchant
-        consentRequest.risk.merchantCategoryCode = "wrongMerchant"
+        consentRequest.risk.merchantCategoryCode = "zzzz"
 
         // Submit standing order
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {


### PR DESCRIPTION
Java Bean validation is now enabled in RS, this enforces schema validations based on the data-model annotations.

Fixing VRP tests to create payment requests which contain all mandatory fields.

Fixing negative tests to use test data that passes schema validation, then triggers biz logic errors

https://github.com/SecureApiGateway/SecureApiGateway/issues/578