### PR TITLE
1012: Fixing tests to work with RCS Consent Store

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/errors/Errors.kt
@@ -8,6 +8,7 @@ const val PAYMENT_SUBMISSION_ALREADY_EXISTS = "Payment submission already exists
 const val B64_HEADER_NOT_PERMITTED = "B64 header not permitted in JWT header after v3.1.3"
 const val UNAUTHORIZED = "Unauthorized"
 const val INVALID_CONSENT_STATUS = "UK.OBIE.Resource.InvalidConsentStatus"
+const val PAYMENT_ACTION_FOR_AUTHORISED_CONSENT_ERROR = "Action can only be performed on consents with status: Authorised. Currently, the consent is: Consumed"
 const val INVALID_DETACHED_JWS_ERROR = "Could not validate detached JWS -"
 const val INVALID_FREQUENCY_VALUE = "Invalid frequency value in the request payload."
 const val REQUEST_EXECUTION_TIME_IN_THE_PAST = "Invalid RequestedExecutionDateTime value in the request payload."

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -5,6 +5,8 @@ import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType
+import com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_CONSENT_STATUS
+import com.forgerock.sapi.gateway.ob.uk.framework.errors.PAYMENT_ACTION_FOR_AUTHORISED_CONSENT_ERROR
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
@@ -33,7 +35,7 @@ class CreateDomesticPayment(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
-        assertThat(result.data.charges).isNotNull().isNotEmpty()
+        assertThat(result.data.charges).isEmpty()
         assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.domesticPaymentId)
     }
 
@@ -81,7 +83,7 @@ class CreateDomesticPayment(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.consentId).isNotEmpty()
-        assertThat(result.data.charges).isNotNull().isNotEmpty()
+        assertThat(result.data.charges).isEmpty()
         assertThat(result.links.self.toString()).isEqualTo(createPaymentUrl + "/" + result.data.domesticPaymentId)
     }
 
@@ -108,8 +110,8 @@ class CreateDomesticPayment(
         }
 
         // Then
-        assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS)
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(403)
+        assertThat(exception.message.toString()).contains(INVALID_CONSENT_STATUS).contains(PAYMENT_ACTION_FOR_AUTHORISED_CONSENT_ERROR)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
     }
 
     fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJwsTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -1,6 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.payments.api.v3_1_8
 
 import assertk.assertThat
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
@@ -38,7 +39,7 @@ class GetDomesticPayment(
         assertThat(getPaymentResponse).isNotNull()
         assertThat(getPaymentResponse.data.domesticPaymentId).isNotEmpty()
         assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
-        assertThat(getPaymentResponse.data.charges).isNotNull().isNotEmpty()
+        assertThat(getPaymentResponse.data.charges).isEmpty()
         Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -89,7 +89,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
         assertThat((exception.cause as FuelError).response.body()).isNotNull()
-        assertThat(exception.message.toString()).contains("Bad request [Failed to get create the resource, 'x-idempotency-key' header / value expected]")
+        assertThat(exception.message.toString()).contains("\"Errors\":[{\"ErrorCode\":\"UK.OBIE.Header.Missing\",\"Message\":\"Missing request header 'x-idempotency-key'")
     }
 
     fun createDomesticPaymentsConsents_withDebtorAccountTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
@@ -68,7 +68,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         apis = ["domestic-payment-consents"]
     )
     @Test
-    @Disabled
+    @Disabled("This has not been implemented in the RS impl of the Consent API")
     fun createDomesticPaymentsConsents_withNonExistentDebtorAccount_v3_1_10() {
         createDomesticPaymentsConsentsApi.createDomesticPaymentsConsents_throwsInvalidDebtorAccountTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
@@ -5,6 +5,7 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
@@ -67,6 +68,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         apis = ["domestic-payment-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticPaymentsConsents_withNonExistentDebtorAccount_v3_1_10() {
         createDomesticPaymentsConsentsApi.createDomesticPaymentsConsents_throwsInvalidDebtorAccountTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -42,7 +42,7 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         assertThat(consent.risk).isNotNull()
     }
 
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest() {
+    fun createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         val idempotencyKey = UUID.randomUUID().toString()
@@ -50,13 +50,13 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         // When
         // first request
         val consentResponse1 = paymentApiClient.newPostRequestBuilder(
-            paymentLinks.CreateDomesticPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
             consentRequest
         ).addIdempotencyKeyHeader(idempotencyKey).sendRequest<OBWriteInternationalConsentResponse6>()
         // second request with the same idempotencyKey
         val consentResponse2 = paymentApiClient.newPostRequestBuilder(
-            paymentLinks.CreateDomesticPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
             consentRequest
         ).addIdempotencyKeyHeader(idempotencyKey).sendRequest<OBWriteInternationalConsentResponse6>()
@@ -77,14 +77,14 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
     }
 
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
+    fun createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
 
         // when
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.newPostRequestBuilder(
-                paymentLinks.CreateDomesticPaymentConsent,
+                paymentLinks.CreateInternationalPaymentConsent,
                 tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
                 consentRequest
             ).deleteIdempotencyKeyHeader().sendRequest<OBWriteInternationalConsentResponse6>()
@@ -95,6 +95,7 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         assertThat((exception.cause as FuelError).response.body()).isNotNull()
         assertThat(exception.message.toString()).contains("Bad request [Failed to get create the resource, 'x-idempotency-key' header / value expected]")
     }
+
     fun createInternationalPaymentsConsents_withDebtorAccountTest() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_10/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_10/CreateInternationalPaymentsConsentsTest.kt
@@ -34,8 +34,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_10(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalPaymentsConsent_NoIdempotencyKey_throwsBadRequestTest_v3_1_10(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(
@@ -45,8 +45,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_10(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_10(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_8/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_8/CreateInternationalPaymentsConsentsTest.kt
@@ -36,8 +36,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_8(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_8(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(
@@ -48,8 +48,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_8(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_8(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
@@ -34,8 +34,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_9(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_9(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(
@@ -45,8 +45,8 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_9(){
-        createInternationalPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_9(){
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -46,7 +46,7 @@ class CreateInternationalScheduledPaymentsConsents(
         assertThat(consent.risk).isNotNull()
     }
 
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest() {
+    fun createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest() {
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
@@ -55,13 +55,13 @@ class CreateInternationalScheduledPaymentsConsents(
         // When
         // first request
         val consentResponse1 = paymentApiClient.newPostRequestBuilder(
-            paymentLinks.CreateDomesticPaymentConsent,
+            paymentLinks.CreateInternationalScheduledPaymentConsent,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
             consentRequest
         ).addIdempotencyKeyHeader(idempotencyKey).sendRequest<OBWriteInternationalScheduledConsentResponse6>()
         // second request with the same idempotencyKey
         val consentResponse2 = paymentApiClient.newPostRequestBuilder(
-            paymentLinks.CreateDomesticPaymentConsent,
+            paymentLinks.CreateInternationalScheduledPaymentConsent,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
             consentRequest
         ).addIdempotencyKeyHeader(idempotencyKey).sendRequest<OBWriteInternationalScheduledConsentResponse6>()
@@ -83,14 +83,14 @@ class CreateInternationalScheduledPaymentsConsents(
 
     }
 
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
+    fun createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         // when
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             paymentApiClient.newPostRequestBuilder(
-                paymentLinks.CreateDomesticPaymentConsent,
+                paymentLinks.CreateInternationalScheduledPaymentConsent,
                 tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
                 consentRequest
             ).deleteIdempotencyKeyHeader().sendRequest<OBWriteInternationalScheduledConsentResponse6>()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -35,8 +35,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_10(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_10(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(
@@ -46,8 +46,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_10(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_10(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -37,8 +37,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_8(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_8(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(
@@ -49,8 +49,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_8(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_8(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -35,8 +35,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_9(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
+    fun createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest_v3_1_9(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_SameIdempotencyKeyMultipleRequestTest()
     }
 
     @EnabledIfVersion(
@@ -46,8 +46,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
-    fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_9(){
-        createInternationalScheduledPaymentsConsents.createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
+    fun createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest_v3_1_9(){
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest()
     }
 
     @EnabledIfVersion(


### PR DESCRIPTION
- Changes to Error messages
- No longer validating that Domestic Payment Consents include charges, as RS impl does not generate any
- Disabling test: createDomesticPaymentsConsents_withNonExistentDebtorAccount_v3_1_10
  - The logic is covered in the RCS when a Payment request is made, if the ResourceOwner does not own the account then the payment fails
  - Raised https://github.com/SecureApiGateway/SecureApiGateway/issues/1041 to review / impl this logic if we want it at a later date
- Fixing International/International Scheduled Payment Idempotency tests which were calling the Domestic API by mistake

https://github.com/SecureApiGateway/SecureApiGateway/issues/1012