### PR TITLE
1013: read refund account response coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -344,4 +344,5 @@ tasks.register<Test>("domestic_vrps_v3_1_10") {
 
 tasks.register<Test>("singleTest") {
     description = "Runs open banking single functional tests"
+    failFast = false
 }

--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -40,7 +40,7 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
  * Functional tests configuration
  */
 // servers
-val environment by extra("jorgesanchezperez")
+val environment by extra("dev")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
 val igServer by extra("https://sapig.$environment.forgerock.financial")

--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -40,7 +40,7 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
  * Functional tests configuration
  */
 // servers
-val environment by extra("dev")
+val environment by extra("jorgesanchezperez")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
 val igServer by extra("https://sapig.$environment.forgerock.financial")

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -66,8 +66,7 @@ class GetDomesticPayment(
         assertThat(getPaymentResponse).isNotNull()
         assertThat(getPaymentResponse.data.domesticPaymentId).isNotEmpty()
         assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-        assertThat(getPaymentResponse.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(getPaymentResponse.data.refund).isNotNull()
         Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -67,6 +67,7 @@ class GetDomesticPayment(
         assertThat(getPaymentResponse.data.domesticPaymentId).isNotEmpty()
         assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
         assertThat(getPaymentResponse.data.refund).isNotNull()
+        assertThat(getPaymentResponse.data.refund.account).isNotNull()
         Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentTest.kt
@@ -35,7 +35,6 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
-    @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")
     fun shouldGetDomesticPayments_withReadRefund_v3_1_10() {
         getDomesticPaymentApi.shouldGetDomesticPayments_withReadRefundTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_8/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_8/GetDomesticPaymentTest.kt
@@ -37,7 +37,6 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")
     fun shouldGetDomesticPayments_withReadRefund_v3_1_8() {
         getDomesticPaymentApi.shouldGetDomesticPayments_withReadRefundTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
@@ -35,7 +35,6 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
-    @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")
     fun shouldGetDomesticPayments_withReadRefund_v3_1_9() {
         getDomesticPaymentApi.shouldGetDomesticPayments_withReadRefundTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
@@ -139,7 +139,6 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
         apis = ["domestic-payments", "domestic-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticPayments_withReadRefund_v3_1_4() {
         // Given
@@ -239,8 +238,8 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         assertThat(paymentResult).isNotNull()
         assertThat(paymentResult.data.domesticPaymentId).isNotEmpty()
         assertThat(paymentResult.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(paymentResult.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(paymentResult.data.refund).isNotNull()
+        assertThat(paymentResult.data.refund.account).isNotNull()
         Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -61,6 +61,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         assertThat(getPaymentResponse.data.domesticScheduledPaymentId).isNotEmpty()
         assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
         assertThat(getPaymentResponse.data.refund).isNotNull()
+        assertThat(getPaymentResponse.data.refund.account).isNotNull()
         Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -60,8 +60,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         assertThat(getPaymentResponse).isNotNull()
         assertThat(getPaymentResponse.data.domesticScheduledPaymentId).isNotEmpty()
         assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(paymentResult.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(getPaymentResponse.data.refund).isNotNull()
         Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentTest.kt
@@ -34,7 +34,6 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
         apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_10() {
         getDomesticScheduledPayment.shouldGetDomesticScheduledPayments_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_8/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_8/GetDomesticScheduledPaymentTest.kt
@@ -36,7 +36,6 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_8() {
         getDomesticScheduledPayment.shouldGetDomesticScheduledPayments_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
@@ -34,7 +34,6 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
         apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_9() {
         getDomesticScheduledPayment.shouldGetDomesticScheduledPayments_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentTest.kt
@@ -137,7 +137,6 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
         apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_4() {
         // Given
@@ -237,8 +236,8 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         assertThat(paymentResult).isNotNull()
         assertThat(paymentResult.data.domesticScheduledPaymentId).isNotEmpty()
         assertThat(paymentResult.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(paymentResult.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(paymentResult.data.refund).isNotNull()
+        assertThat(paymentResult.data.refund.account).isNotNull()
         Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -82,8 +82,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         assertThat(getStandingOrderResponse).isNotNull()
         assertThat(getStandingOrderResponse.data.domesticStandingOrderId).isNotEmpty()
         assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(getStandingOrderResponse.data.refund).isNotNull()
         Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -83,6 +83,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         assertThat(getStandingOrderResponse.data.domesticStandingOrderId).isNotEmpty()
         assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
         assertThat(getStandingOrderResponse.data.refund).isNotNull()
+        assertThat(getStandingOrderResponse.data.refund.account).isNotNull()
         Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderTest.kt
@@ -45,7 +45,6 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_10() {
         getDomesticStandingOrder.shouldGetDomesticStandingOrders_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_8/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_8/GetDomesticStandingOrderTest.kt
@@ -48,7 +48,6 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_8() {
         getDomesticStandingOrder.shouldGetDomesticStandingOrders_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
@@ -45,7 +45,6 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_9() {
         getDomesticStandingOrder.shouldGetDomesticStandingOrders_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderTest.kt
@@ -246,7 +246,6 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_4() {
         // Given
@@ -346,8 +345,8 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         assertThat(result).isNotNull()
         assertThat(result.data.domesticStandingOrderId).isNotEmpty()
         assertThat(result.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(result.data.refund).isNotNull()
+        assertThat(result.data.refund.account).isNotNull()
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -112,8 +112,8 @@ class GetInternationalPayment(
         assertThat(result.data.internationalPaymentId).isNotEmpty()
         assertThat(result.data.creationDateTime).isNotNull()
         assertThat(result.data.charges).isNotNull().isNotEmpty()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(result.data.refund).isNotNull()
+        assertThat(result.data.refund.account).isNotNull()
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentTest.kt
@@ -67,7 +67,6 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
         apis = ["international-payments", "international-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalPayments_withReadRefund_v3_1_10() {
         getInternationalPayment.shouldGetInternationalPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_8/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_8/GetInternationalPaymentTest.kt
@@ -72,7 +72,6 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalPayments_withReadRefund_v3_1_8() {
         getInternationalPayment.shouldGetInternationalPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
@@ -67,7 +67,6 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
         apis = ["international-payments", "international-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalPayments_withReadRefund_v3_1_9() {
         getInternationalPayment.shouldGetInternationalPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentTest.kt
@@ -453,7 +453,6 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
         apis = ["international-payments", "international-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalPayments_withReadRefund_v3_1_4() {
         // Given
@@ -553,8 +552,8 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         assertThat(result).isNotNull()
         assertThat(result.data.internationalPaymentId).isNotEmpty()
         assertThat(result.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(result.data.refund).isNotNull()
+        assertThat(result.data.refund.account).isNotNull()
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -113,8 +113,8 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         assertThat(result).isNotNull()
         assertThat(result.data.internationalScheduledPaymentId).isNotEmpty()
         assertThat(result.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(result.data.refund).isNotNull()
+        assertThat(result.data.refund.account).isNotNull()
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentTest.kt
@@ -67,7 +67,6 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalScheduledPayments_withReadRefund_v3_1_10() {
         getInternationalScheduledPayment.shouldGetInternationalScheduledPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_8/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_8/GetInternationalScheduledPaymentTest.kt
@@ -72,7 +72,6 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalScheduledPayments_withReadRefund_v3_1_8() {
         getInternationalScheduledPayment.shouldGetInternationalScheduledPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
@@ -67,7 +67,6 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalScheduledPayments_withReadRefund_v3_1_9() {
         getInternationalScheduledPayment.shouldGetInternationalScheduledPayments_withReadRefund_Test()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentTest.kt
@@ -553,8 +553,8 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         assertThat(result).isNotNull()
         assertThat(result.data.internationalScheduledPaymentId).isNotEmpty()
         assertThat(result.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(result.data.refund).isNotNull()
+        assertThat(result.data.refund.account).isNotNull()
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrder.kt
@@ -82,8 +82,8 @@ class GetInternationalStandingOrder(val version: OBVersion, val tppResource: Cre
         assertThat(getStandingOrderResponse).isNotNull()
         assertThat(getStandingOrderResponse.data.internationalStandingOrderId).isNotEmpty()
         assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
-        //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-//        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        assertThat(getStandingOrderResponse.data.refund).isNotNull()
+        assertThat(getStandingOrderResponse.data.refund.account).isNotNull()
         Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/GetInternationalStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/GetInternationalStandingOrderTest.kt
@@ -45,7 +45,6 @@ class GetInternationalStandingOrderTest(val tppResource: CreateTppCallback.TppRe
         operations = ["GetInternationalStandingOrder", "CreateInternationalStandingOrder", "CreateInternationalStandingOrderConsent", "GetInternationalStandingOrderConsent"],
         apis = ["international-standing-orders", "international-standing-order-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalStandingOrders_withReadRefund_v3_1_10() {
         getInternationalStandingOrder.shouldGetInternationalStandingOrders_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_8/GetInternationalStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_8/GetInternationalStandingOrderTest.kt
@@ -48,7 +48,6 @@ class GetInternationalStandingOrderTest(val tppResource: CreateTppCallback.TppRe
         apis = ["international-standing-orders", "international-standing-order-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalStandingOrders_withReadRefund_v3_1_8() {
         getInternationalStandingOrder.shouldGetInternationalStandingOrders_withReadRefundTest()

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_9/GetInternationalStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_9/GetInternationalStandingOrderTest.kt
@@ -45,7 +45,6 @@ class GetInternationalStandingOrderTest(val tppResource: CreateTppCallback.TppRe
         operations = ["GetInternationalStandingOrder", "CreateInternationalStandingOrder", "CreateInternationalStandingOrderConsent", "GetInternationalStandingOrderConsent"],
         apis = ["international-standing-orders", "international-standing-order-consents"]
     )
-    @Disabled
     @Test
     fun shouldGetInternationalStandingOrders_withReadRefund_v3_1_9() {
         getInternationalStandingOrder.shouldGetInternationalStandingOrders_withReadRefundTest()


### PR DESCRIPTION
- Fix read refund account tests coverage
- Enable read refund account tests coverage

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1013