### PR TITLE
1035: Fixing Consent not found error code and message assertion

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
@@ -47,7 +47,7 @@ class AccountAccessConsent(val version: OBVersion, val tppResource: CreateTppCal
                 consent.data.consentId
             )
         }
-        assertThat(error.message).matchesPredicate { msg -> msg!!.contains("\"ErrorCode\":\"UK.OBIE.NotFound\",\"Message\":\"Resource not found\"") }
+        assertThat(error.message).matchesPredicate { msg -> msg!!.contains("\"ErrorCode\":\"OBRI.Consent.Not.Found\",\"Message\":\"Consent not found\"") }
     }
 
     fun getAccountAccessConsentTest() {


### PR DESCRIPTION
RS impl of AccountAccessConsentApi produces different errors to the IG impl, fixing error code and message assertion to work with the new format.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1035