### PR TITLE
1050: Fixing idempotency error message

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
@@ -68,7 +68,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         apis = ["domestic-payment-consents"]
     )
     @Test
-    @Disabled("This has not been implemented in the RS impl of the Consent API")
+    @Disabled("Functionality not yet implemented in the RS Consent API - issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1041")
     fun createDomesticPaymentsConsents_withNonExistentDebtorAccount_v3_1_10() {
         createDomesticPaymentsConsentsApi.createDomesticPaymentsConsents_throwsInvalidDebtorAccountTest()
     }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
@@ -100,7 +100,7 @@ class CreateDomesticVrpConsents(val version: OBVersion, val tppResource: CreateT
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
         assertThat((exception.cause as FuelError).response.body()).isNotNull()
-        assertThat(exception.message.toString()).contains("Bad request [Failed to get create the resource, 'x-idempotency-key' header / value expected]")
+        assertThat(exception.message.toString()).contains("\"Errors\":[{\"ErrorCode\":\"UK.OBIE.Header.Missing\",\"Message\":\"Missing request header 'x-idempotency-key'")
     }
 
     fun createDomesticVrpConsent_throwsInvalidDebtorAccountTest() {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/junit/v3_1_10/CreateDomesticVrpConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/junit/v3_1_10/CreateDomesticVrpConsentsTest.kt
@@ -5,6 +5,7 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.vrp.consents.api.v3_1_10.CreateDomesticVrpConsents
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class CreateDomesticVrpConsentsTest(val tppResource: CreateTppCallback.TppResource) {
@@ -67,6 +68,7 @@ class CreateDomesticVrpConsentsTest(val tppResource: CreateTppCallback.TppResour
         apis = ["domestic-vrp-consents"]
     )
     @Test
+    @Disabled("Functionality not yet implemented in the RS Consent API - issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1041")
     fun createDomesticVrpConsents_throwsInvalidDebtorAccount_v3_1_10() {
         createDomesticVrpConsents.createDomesticVrpConsent_throwsInvalidDebtorAccountTest()
     }


### PR DESCRIPTION
Disabling createDomesticVrpConsents_throwsInvalidDebtorAccount_v3_1_10 as this logic has not been implemented. See issue 1041

https://github.com/SecureApiGateway/SecureApiGateway/issues/1050