### PR TITLE
1057: Adding tests to validate VRP refund account is set correctly when requested

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpTest.kt
@@ -28,4 +28,15 @@ class GetDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
         getDomesticVrpPaymentApi.getDomesticVrpPaymentsTest()
     }
 
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        apis = ["domestic-vrps", "domestic-vrp-consents"]
+    )
+    @Test
+    fun getDomesticVrpPaymentsWithRefundAccount_v3_1_10() {
+        getDomesticVrpPaymentApi.getDomesticVrpPaymentsWithRefundAccountTest()
+    }
+
 }


### PR DESCRIPTION
https://github.com/SecureApiGateway/SecureApiGateway/issues/1057