### PR TITLE
1052: Testing that funds confirmation requests fail when requested consentId is not authorised for the access_token provided

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -60,4 +60,15 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_10() {
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId_v3_1_10() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/junit/v3_1_10/CreateDomesticVrpConsentsFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/junit/v3_1_10/CreateDomesticVrpConsentsFundsConfirmationTest.kt
@@ -49,5 +49,16 @@ class CreateDomesticVrpConsentsFundsConfirmationTest(val tppResource: CreateTppC
     fun shouldCreateDomesticVRPConsentsConsentIdFundsConfirmation_available_v3_1_10() {
         createDomesticVrpConsentsFundsConfirmationApi.shouldCreateDomesticVRPConsentsConsentIdFundsConfirmation_available()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticVRPConsent", "CreateDomesticVRPConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-vrp-consents"]
+    )
+    @Test
+    fun shouldFailIfAccessTokenConsentIdDoesNotMatchRequestConsentId_3_1_10() {
+        createDomesticVrpConsentsFundsConfirmationApi.shouldFailIfAccessTokenConsentIdDoesNotMatchFundsConfPostRequestConsentId()
+    }
 }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -105,4 +105,15 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_10() {
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -104,4 +104,16 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
     fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_10() {
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldFailIfAccessTokenConsentIdDoesNotMatchRequestUriPathParamConsentId()
+    }
+
 }


### PR DESCRIPTION
Tests for: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk/pull/413

https://github.com/SecureApiGateway/SecureApiGateway/issues/1052