### PR TITLE
1075: Updating VRP payment operation names

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/discovery/RsDiscovery.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/discovery/RsDiscovery.kt
@@ -327,13 +327,13 @@ data class RsDiscovery(
                     val GetInternationalScheduledPaymentPaymentIdPaymentDetails: String,
                     val GetInternationalStandingOrderInternationalStandingOrderIdPaymentDetails: String,
                     val CreateDomesticVRPConsent: String,
-                    val CreateDomesticVrpPayment: String,
+                    val CreateDomesticVRPPayment: String,
                     val GetDomesticVRPConsent: String,
                     val DeleteDomesticVRPConsent: String,
                     val GetDomesticVRP: String,
-                    val GetDomesticVrpPaymentDetails: String,
+                    val GetDomesticVRPPaymentDetails: String,
                     val CreateDomesticVRPConsentsConsentIdFundsConfirmation: String,
-                    val GetDomesticVrpPayment: String
+                    val GetDomesticVRPPayment: String
                 )
             }
         }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -27,7 +27,7 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
     private val createDomesticVrpConsentsApi = CreateDomesticVrpConsents(version, tppResource)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
     private val paymentLinks = getPaymentsApiLinks(version)
-    private val createPaymentUrl = paymentLinks.CreateDomesticVrpPayment
+    private val createPaymentUrl = paymentLinks.CreateDomesticVRPPayment
 
     fun createDomesticVrpPaymentTest() {
         // Given

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrp.kt
@@ -63,7 +63,7 @@ class GetDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallback.
 
     private fun getDomesticVrpPayment(paymentResponse: OBDomesticVRPResponse): OBDomesticVRPResponse {
         val getDomesticVrpPaymentUrl = PaymentFactory.urlWithDomesticVrpPaymentId(
-            paymentLinks.GetDomesticVrpPayment,
+            paymentLinks.GetDomesticVRPPayment,
             paymentResponse.data.domesticVRPId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
@@ -72,7 +72,7 @@ class GetDomesticVrpDetails(
 
     private fun getDomesticVrpDetails(domesticVrpResponse: OBDomesticVRPResponse): OBWritePaymentDetailsResponse1 {
         val getDomesticVrpDetailsUrl = PaymentFactory.urlWithDomesticVrpPaymentId(
-            paymentLinks.GetDomesticVrpPaymentDetails,
+            paymentLinks.GetDomesticVRPPaymentDetails,
             domesticVrpResponse.data.domesticVRPId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -20,7 +20,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -31,7 +31,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
             type = "payments",
             apiVersion = "v3.1.10",
-            operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+            operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
             apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -42,7 +42,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -53,7 +53,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -64,7 +64,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
      @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -75,7 +75,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -86,7 +86,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -97,7 +97,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -108,7 +108,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -119,7 +119,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -130,7 +130,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -141,7 +141,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -152,7 +152,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
             type = "payments",
             apiVersion = "v3.1.10",
-            operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+            operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
             apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpDetailsTest.kt
@@ -20,7 +20,7 @@ class GetDomesticVrpDetailsTest(val tppResource: CreateTppCallback.TppResource) 
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVrpPaymentDetails"],
+        operations = ["GetDomesticVRPPayment", "CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVRPPaymentDetails"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -31,7 +31,7 @@ class GetDomesticVrpDetailsTest(val tppResource: CreateTppCallback.TppResource) 
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVrpPaymentDetails"],
+        operations = ["GetDomesticVRPPayment", "CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVRPPaymentDetails"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -42,7 +42,7 @@ class GetDomesticVrpDetailsTest(val tppResource: CreateTppCallback.TppResource) 
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVrpPaymentDetails"],
+        operations = ["GetDomesticVRPPayment", "CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVRPPaymentDetails"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpTest.kt
@@ -20,7 +20,7 @@ class GetDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["GetDomesticVRPPayment", "CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
@@ -31,7 +31,7 @@ class GetDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        operations = ["GetDomesticVRPPayment", "CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentDetailsTest.kt
@@ -20,7 +20,7 @@ class GetInternationalScheduledPaymentDetailsTest(val tppResource: CreateTppCall
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
@@ -31,7 +31,7 @@ class GetInternationalScheduledPaymentDetailsTest(val tppResource: CreateTppCall
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
@@ -42,7 +42,7 @@ class GetInternationalScheduledPaymentDetailsTest(val tppResource: CreateTppCall
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
@@ -53,7 +53,7 @@ class GetInternationalScheduledPaymentDetailsTest(val tppResource: CreateTppCall
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",
-        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test


### PR DESCRIPTION
The VRP payment operations names have been updated to use names consistent with the consent operations.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1075