### PR TITLE
958: Testing payment submission idempotency

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
@@ -136,4 +136,16 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
     fun shouldCreateDomesticPayments_throwsInvalidRisk_v3_1_10() {
         createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createDomesticPaymentApi.testCreatingPaymentIsIdempotent()
+    }
+
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -1,11 +1,5 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8
 
-import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.isEmpty
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
-import assertk.assertions.isNotNull
 import com.forgerock.sapi.gateway.framework.conditions.Status
 import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
@@ -17,9 +11,10 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
+import java.util.UUID
 
 class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
@@ -75,7 +70,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
             .amount("123123")
@@ -100,7 +95,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // Submit first payment
         submitPaymentForConsent(consentResponse.data.consentId, consentRequest, accessTokenAuthorizationCode)
@@ -126,7 +121,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -154,7 +149,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -183,7 +178,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -212,7 +207,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -241,7 +236,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -276,7 +271,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -316,7 +311,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
 
@@ -331,6 +326,32 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         // Then
         assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_RISK)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+    }
+
+    fun testCreatingPaymentIsIdempotent() {
+        val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
+        val (consent, authorizationToken) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        val paymentSubmissionRequest = createPaymentRequest(consent.data.consentId, consentRequest)
+
+        val idempotencyKey = UUID.randomUUID().toString()
+        val firstPaymentResponse:OBWriteDomesticScheduledResponse5 = paymentApiClient.newPostRequestBuilder(createPaymentUrl, authorizationToken, paymentSubmissionRequest)
+            .addIdempotencyKeyHeader(idempotencyKey)
+            .sendRequest()
+
+        assertThat(firstPaymentResponse).isNotNull()
+        assertThat(firstPaymentResponse.data).isNotNull()
+        assertThat(firstPaymentResponse.data.consentId).isNotEmpty()
+        assertThat(firstPaymentResponse.data.charges).isEmpty()
+        assertThat(firstPaymentResponse.links.self.toString()).isEqualTo(createPaymentUrl + "/" + firstPaymentResponse.data.domesticScheduledPaymentId)
+
+        // Submit again with same key
+        val secondPaymentResponse:OBWriteDomesticScheduledResponse5 = paymentApiClient.newPostRequestBuilder(createPaymentUrl, authorizationToken, paymentSubmissionRequest)
+            .addIdempotencyKeyHeader(idempotencyKey)
+            .sendRequest()
+
+        assertThat(secondPaymentResponse).isEqualTo(firstPaymentResponse)
     }
 
     fun submitPayment(consentRequest: OBWriteDomesticScheduledConsent4): OBWriteDomesticScheduledResponse5 {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
@@ -139,4 +139,15 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
     fun shouldCreateDomesticPayments_throwsInvalidRisk_v3_1_10() {
         createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createDomesticScheduledPayment.testCreatingPaymentIsIdempotent()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
@@ -150,4 +150,15 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
     fun shouldCreateDomesticStandingOrder_throwsInvalidRiskTest_v3_1_10() {
         createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createDomesticStandingOrder.testCreatingPaymentIsIdempotent()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -159,4 +159,17 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     fun shouldFailToCreateVrpWhenMaxIndividualAmountBreachedTest_v3_1_10() {
         createDomesticVrpPayment.shouldFailToCreateVrpWhenMaxIndividualAmountBreachedTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticVRPPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        apis = ["domestic-vrps", "domestic-vrp-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createDomesticVrpPayment.testCreatingPaymentIsIdempotent()
+    }
+
+
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/junit/v3_1_10/CreateFilePaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/junit/v3_1_10/CreateFilePaymentTest.kt
@@ -116,4 +116,15 @@ class CreateFilePaymentTest(val tppResource: CreateTppCallback.TppResource) {
     fun shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createFilePayment.shouldCreateFilePayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePayment", "CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payments", "file-payment-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createFilePayment.testCreatingPaymentIsIdempotent()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -1,20 +1,20 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.payments.api.v3_1_8
 
-import assertk.assertThat
-import assertk.assertions.*
 import com.forgerock.sapi.gateway.framework.conditions.Status
 import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType
+import com.forgerock.sapi.gateway.ob.uk.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
+import java.util.UUID
 
 class CreateInternationalPayment(
     val version: OBVersion,
@@ -134,7 +134,7 @@ class CreateInternationalPayment(
         assertThat(result.data.consentId).isNotEmpty()
         assertThat(result.data.charges).isNotNull().isEmpty()
         assertThat(result.data.exchangeRateInformation).isNotNull()
-        assertThat(result.data.exchangeRateInformation.exchangeRate.compareTo(consentResponse.data.exchangeRateInformation.exchangeRate)).equals(0)
+        assertThat(result.data.exchangeRateInformation.exchangeRate.compareTo(consentResponse.data.exchangeRateInformation.exchangeRate)).isEqualTo(0)
         assertThat(result.data.exchangeRateInformation.rateType).isEqualTo(consentResponse.data.exchangeRateInformation.rateType)
         assertThat(result.data.exchangeRateInformation.unitCurrency).isEqualTo(consentResponse.data.exchangeRateInformation.unitCurrency)
     }
@@ -150,7 +150,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         consentRequest.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount()
             .amount("123123")
@@ -178,7 +178,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
         // Submit first payment
@@ -191,8 +191,8 @@ class CreateInternationalPayment(
         }
 
         // Then
-        assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_CONSENT_STATUS)
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(PAYMENT_SUBMISSION_ALREADY_EXISTS)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(403)
     }
 
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_Test() {
@@ -205,7 +205,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -230,7 +230,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -254,7 +254,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -279,7 +279,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -304,7 +304,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -335,7 +335,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createPaymentRequest(consentResponse.data.consentId, consentRequest)
 
@@ -373,7 +373,7 @@ class CreateInternationalPayment(
         assertThat(consentResponse).isNotNull()
         assertThat(consentResponse.data).isNotNull()
         assertThat(consentResponse.data.consentId).isNotEmpty()
-        Assertions.assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consentResponse.data.status.toString()).`is`(Status.consentCondition)
 
         // When
 
@@ -388,6 +388,32 @@ class CreateInternationalPayment(
         // Then
         assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.INVALID_RISK)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+    }
+
+    fun testCreatingPaymentIsIdempotent() {
+        val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
+        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        val paymentSubmissionRequest = createPaymentRequest(consent.data.consentId, consentRequest)
+
+        val idempotencyKey = UUID.randomUUID().toString()
+        val firstPaymentResponse:OBWriteInternationalResponse5 = paymentApiClient.newPostRequestBuilder(createPaymentUrl, authorizationToken, paymentSubmissionRequest)
+            .addIdempotencyKeyHeader(idempotencyKey)
+            .sendRequest()
+
+        assertThat(firstPaymentResponse).isNotNull()
+        assertThat(firstPaymentResponse.data).isNotNull()
+        assertThat(firstPaymentResponse.data.consentId).isNotEmpty()
+        assertThat(firstPaymentResponse.data.charges).isEmpty()
+        assertThat(firstPaymentResponse.links.self.toString()).isEqualTo(createPaymentUrl + "/" + firstPaymentResponse.data.internationalPaymentId)
+
+        // Submit again with same key
+        val secondPaymentResponse:OBWriteInternationalResponse5 = paymentApiClient.newPostRequestBuilder(createPaymentUrl, authorizationToken, paymentSubmissionRequest)
+            .addIdempotencyKeyHeader(idempotencyKey)
+            .sendRequest()
+
+        assertThat(secondPaymentResponse).isEqualTo(firstPaymentResponse)
     }
 
     fun submitPayment(consentRequest: OBWriteInternationalConsent5): OBWriteInternationalResponse5 {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
@@ -169,4 +169,15 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
     fun shouldCreateInternationalPayments_throwsInvalidRiskTest_v3_1_10() {
         createInternationalPayment.shouldCreateInternationalPayments_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createInternationalPayment.testCreatingPaymentIsIdempotent()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
@@ -171,4 +171,15 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
     fun shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest_v3_1_10() {
         createInternationalScheduledPayment.shouldCreateInternationalScheduledPayments_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createInternationalScheduledPayment.testCreatingPaymentIsIdempotent()
+    }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/CreateInternationalStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/junit/v3_1_10/CreateInternationalStandingOrderTest.kt
@@ -149,4 +149,15 @@ class CreateInternationalStandingOrderTest(val tppResource: CreateTppCallback.Tp
     fun shouldCreateInternationalStandingOrder_throwsInvalidRiskTest_v3_1_10() {
         createInternationalStandingOrder.shouldCreateInternationalStandingOrder_throwsInvalidRiskTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalStandingOrder", "CreateInternationalStandingOrderConsent", "GetInternationalStandingOrderConsent"],
+        apis = ["international-standing-orders", "international-standing-order-consents"]
+    )
+    @Test
+    fun testCreatingPaymentIsIdempotent_v3_1_10() {
+        createInternationalStandingOrder.testCreatingPaymentIsIdempotent()
+    }
 }


### PR DESCRIPTION
Adding a test to each payment type to verify that submission is idempotent when a duplicate request is submitted (with same x-idempotency-key and body)

https://github.com/SecureApiGateway/SecureApiGateway/issues/958