### PR TITLE
1095: File Payment Consent test for unsupported fileType

### DIFF
--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -99,7 +99,7 @@ class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: Create
         assertThat(consentResponse2.data.consentId).isNotEmpty()
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
     }
 
     fun createFilePaymentConsents_NoIdempotencyKey_throwsBadRequestTest() {
@@ -155,7 +155,7 @@ class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: Create
         // Then
         assertThat(response1).isNotNull()
         assertThat(response2).isNotNull()
-        assertThat(response1).equals(response2)
+        assertThat(response1).isEqualTo(response2)
     }
 
     fun submitFile_NoIdempotencyKey_throwsBadRequestTest() {
@@ -352,6 +352,20 @@ class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: Create
 
         // Then
         assertThat(exception.message.toString()).contains(com.forgerock.sapi.gateway.ob.uk.framework.errors.CONSENT_NOT_AUTHORISED)
+    }
+
+    fun failToCreateConsentForUnsupportedFileType() {
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
+        val fileType = PaymentFileType.UK_OBIE_PAIN_001_001_008
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            "FR_FORMAT_123"
+        )
+
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            sendSubmitFileRequest(consentRequest, fileContent, fileType.mediaType)
+        }
+        assertThat(exception.message.toString()).contains("\"ErrorCode\":\"OBRI.Request.File.Payment.FileType.Not.Supported\"")
     }
 
     fun createFilePaymentConsent(consentRequest: OBWriteFileConsent3): OBWriteFileConsentResponse4 {

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
@@ -5,7 +5,6 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.EnabledIfVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class CreateFilePaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
@@ -170,5 +169,16 @@ class CreateFilePaymentConsentsTest(val tppResource: CreateTppCallback.TppResour
     @Test
     fun shouldCreateFilePaymentsConsents_throwsRejectedConsent_v3_1_10() {
         createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsRejectedConsentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun failToCreateConsentForUnsupportedFileType_v3_1_10() {
+        createFilePaymentsConsentsApi.failToCreateConsentForUnsupportedFileType()
     }
 }


### PR DESCRIPTION
Verify that creating a File Payment Consent for an unsupported fileType returns the appropriate error.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1095