### PR TITLE
1001: aggregated polling test coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,13 +75,14 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:2.0.0"))
+    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:2.0.3"))
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-shared")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-error")
     testImplementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel:jar:tests")
     testImplementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel:jar:tests")
+    testImplementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-rs-resource-store-datamodel:2.0.2")
 
     testImplementation("org.bouncycastle:bcprov-jdk15on:1.70")
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
@@ -339,6 +340,7 @@ for (apiVersion in apiVersions) {
             includeTestsMatching(packagePrefix + "payment.file.payments" + suffixPattern + apiVersion)
             includeTestsMatching(packagePrefix + "payment.domestic.vrp" + suffixPattern + apiVersion)
             includeTestsMatching(packagePrefix + "funds" + suffixPattern + apiVersion)
+            includeTestsMatching(packagePrefix + "events" + suffixPattern + apiVersion)
         }
         failFast = false
     }
@@ -349,6 +351,15 @@ tasks.register<Test>("domestic_vrps_v3_1_10") {
     description = "Runs the domestic vrps tests with the version v3_1_10"
     filter {
         includeTestsMatching(packagePrefix + "payment.domestic.vrp" + suffixPattern + "v3_1_10")
+    }
+    failFast = false
+}
+
+tasks.register<Test>("events_v3_1_10") {
+    group = "events-tests"
+    description = "Runs the events notification tests with the version v3_1_10"
+    filter {
+        includeTestsMatching(packagePrefix + "events" + suffixPattern + "v3_1_10")
     }
     failFast = false
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventNotificationRS.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventNotificationRS.kt
@@ -1,0 +1,93 @@
+package com.forgerock.sapi.gateway.ob.uk.support.event
+
+import com.forgerock.sapi.gateway.framework.configuration.MTLS_SERVER
+import com.forgerock.sapi.gateway.framework.data.AccessToken
+import com.forgerock.sapi.gateway.framework.data.Tpp
+import com.forgerock.sapi.gateway.framework.http.fuel.jsonBody
+import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.isSuccessful
+import uk.org.openbanking.datamodel.event.OBEventPolling1
+
+const val EVENT_ADMIN_API_SCOPES = "openid payments accounts fundsconfirmations"
+
+class EventNotificationRS {
+
+    fun getClientCredentialsAdminAccessToken(tpp: Tpp): AccessToken {
+        return tpp.getClientCredentialsAccessToken(EVENT_ADMIN_API_SCOPES)
+    }
+
+    fun getClientCredentialsAccessToken(tpp: Tpp, scopes: List<String>): AccessToken {
+        return tpp.getClientCredentialsAccessToken(scopes.joinToString(separator = " "))
+    }
+
+    fun getEventsAdminAPIUrl(): String {
+        return "${MTLS_SERVER}/rs/admin/data/events"
+    }
+
+    inline fun <reified T : Any> importDataEvent(
+            eventRequest: EventsDataFactory.Companion.FRDataEvent, accessToken: String
+    ): T {
+        val (_, response, result) = Fuel.post(getEventsAdminAPIUrl())
+                .jsonBody(eventRequest)
+                .header("Authorization", "Bearer $accessToken")
+                .responseObject<T>()
+        if (!response.isSuccessful) throw AssertionError(
+                "Could not import event: ${String(response.data)}",
+                result.component2()
+        )
+        return result.get()
+    }
+
+    inline fun <reified T : Any> exportEvents(apiClientId: String, adminAccessToken: String): T {
+        val (_, response, result) = Fuel.get(getEventsAdminAPIUrl() + "?apiClientId=$apiClientId")
+                .header("Authorization", "Bearer $adminAccessToken")
+                .responseObject<T>()
+        if (!response.isSuccessful) throw AssertionError(
+                "Could not export events: ${String(response.data)}",
+                result.component2()
+        )
+        return result.get()
+    }
+
+    fun deleteImportedEvents(events: FREventMessages, adminAccessToken: String) {
+        val apiClientId = events.apiClientId
+        events.events.forEach { event ->
+            deleteEvent(event.jti, apiClientId, adminAccessToken)
+        }
+    }
+
+    private fun deleteEvent(jti: String, apiClientId: String, adminAccessToken: String) {
+        val (_, consentResponse, r) = Fuel.delete(
+                getEventsAdminAPIUrl() +
+                        "?apiClientId=$apiClientId" +
+                        "&jti=$jti"
+        )
+                .header("Authorization", "Bearer $adminAccessToken")
+                .responseObject<Void>()
+        if (!consentResponse.isSuccessful) throw AssertionError(
+                "Could not delete event: ${String(consentResponse.data)}",
+                r.component2()
+        )
+    }
+
+    inline fun <reified T : Any> postAggregatedPolling(
+            aggregatedPollingUrl: String,
+            aggregatedPollingRequest: OBEventPolling1,
+            tpp: Tpp,
+            scopes: List<String> = listOf("payments")
+    ): T {
+        val accessToken = getClientCredentialsAccessToken(tpp, scopes).access_token
+        val (_, consentResponse, r) = Fuel.post(aggregatedPollingUrl)
+                .jsonBody(aggregatedPollingRequest)
+                .header("Authorization", "Bearer $accessToken")
+                .header("x-api-client-id", tpp.registrationResponse.client_id)
+                .responseObject<T>()
+        if (!consentResponse.isSuccessful) throw AssertionError(
+                "Error polling events: ${String(consentResponse.data)}",
+                r.component2()
+        )
+        return r.get()
+    }
+}

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventsDataFactory.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventsDataFactory.kt
@@ -1,55 +1,59 @@
 package com.forgerock.sapi.gateway.ob.uk.support.event
 
-import com.forgerock.sapi.gateway.framework.data.Tpp
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.FRDataEvent
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.OBEventNotification2
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import uk.org.openbanking.datamodel.event.*
+import java.util.UUID
 
 class EventsDataFactory {
 
     companion object {
         fun aCallbackUrlRequest(version: OBVersion): OBCallbackUrl1 {
             return OBCallbackUrl1().data(
-                OBCallbackUrlData1()
-                    .url(tppEventNotificationsUrl(version))
-                    .version(version.canonicalVersion)
+                    OBCallbackUrlData1()
+                            .url(tppEventNotificationsUrl(version))
+                            .version(version.canonicalVersion)
             )
         }
 
         fun anEventSubscriptionRequest(version: OBVersion): OBEventSubscription1 {
             return OBEventSubscription1().data(
-                OBEventSubscription1Data()
-                    .version(version.canonicalVersion)
-                    .callbackUrl(tppEventNotificationsUrl(version))
+                    OBEventSubscription1Data()
+                            .version(version.canonicalVersion)
+                            .callbackUrl(tppEventNotificationsUrl(version))
             )
         }
 
-        fun anEventDataRequest(tpp: Tpp, version: OBVersion): FRDataEvent {
-            return FRDataEvent().tppId(tpp.registrationResponse.client_id)
-                .addOBEventNotification2Item(
-                    OBEventNotification2()
-                        .iss("https://examplebank.com/")
-                        .iat(1516239022)
-                        .jti("b460a07c-4962-43d1-85ee-9dc10fbb8f6c")
-                        .sub("https://examplebank.com/api/open-banking/${version.canonicalName}/pisp/domestic-payments/pmt-7290-003")
-                        .aud("7umx5nTR33811QyQfi")
-                        .txn("dfc51628-3479-4b81-ad60-210b43d02306")
-                        .toe(1516239022)
-                        .events(
+        fun aValidFRDataEvent(
+                events: List<OBEventNotification1>,
+                apiClientId: String
+        ): FRDataEvent {
+            return FRDataEvent(apiClientId, events)
+        }
+
+        fun aValidOBEventNotification1(version: OBVersion): OBEventNotification1 {
+            return OBEventNotification1()
+                    .iss("https://examplebank.com/")
+                    .iat(1516239022)
+                    .jti(UUID.randomUUID().toString())
+                    .sub("https://examplebank.com/api/open-banking/${version.canonicalName}/pisp/domestic-payments/pmt-7290-003")
+                    .aud("7umx5nTR33811QyQfi")
+                    .txn(UUID.randomUUID().toString())
+                    .toe(1516239022)
+                    .events(
                             OBEvent1().urnukorgopenbankingeventsresourceUpdate(
-                                OBEventResourceUpdate1().subject(
-                                    OBEventSubject1().subjectType("http://openbanking.org.uk/rid_http://openbanking.org.uk/rty")
-                                        .httpopenbankingOrgUkrid("pmt-7290-003")
-                                        .httpopenbankingOrgUkrty("domestic-payment")
-                                        .addHttpopenbankingOrgUkrlkItem(
-                                            OBEventLink1().link("https://examplebank.com/api/open-banking/${version.canonicalName}/pisp/domestic-payments/pmt-7290-003")
-                                                .version(version.canonicalVersion)
-                                        )
-                                )
+                                    OBEventResourceUpdate1().subject(
+                                            OBEventSubject1().subjectType("http://openbanking.org.uk/rid_http://openbanking.org.uk/rty")
+                                                    .httpopenbankingOrgUkrid("pmt-7290-003")
+                                                    .httpopenbankingOrgUkrty("domestic-payment")
+                                                    .addHttpopenbankingOrgUkrlkItem(
+                                                            OBEventLink1().link("https://examplebank.com/api/open-banking/${version.canonicalName}/pisp/domestic-payments/pmt-7290-003")
+                                                                    .version(version.canonicalVersion)
+                                                    )
+                                    )
                             )
-                        )
-                )
+                    )
+
+
         }
 
         private fun tppEventNotificationsUrl(version: OBVersion): String {
@@ -57,5 +61,10 @@ class EventsDataFactory {
             // Endpoint POST /event-notifications
             return "https://tpp.domain.test.net/open-banking/${version.canonicalName}/event-notifications"
         }
+
+        data class FRDataEvent(
+                val apiClientId: String,
+                val events: List<OBEventNotification1>
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/api/v3_1_10/AggregatedPolling.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/api/v3_1_10/AggregatedPolling.kt
@@ -1,0 +1,145 @@
+package com.forgerock.sapi.gateway.ob.uk.tests.functional.events.aggregatedpolling.api.v3_1_10
+
+import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
+import com.forgerock.sapi.gateway.ob.uk.support.discovery.getEventsApiLinks
+import com.forgerock.sapi.gateway.ob.uk.support.event.EventNotificationRS
+import com.forgerock.sapi.gateway.ob.uk.support.event.EventsDataFactory
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
+import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.event.OBEventPolling1
+import uk.org.openbanking.datamodel.event.OBEventPolling1SetErrs
+import uk.org.openbanking.datamodel.event.OBEventPollingResponse1
+import kotlin.streams.toList
+
+class AggregatedPolling(
+        val version: OBVersion,
+        val tppResource: CreateTppCallback.TppResource
+) {
+
+    private val eventAggregatedPollingLinks = getEventsApiLinks(version)
+    private val eventAggregatedPollingUrl = eventAggregatedPollingLinks.EventAggregatedPolling
+
+    fun shouldInitialPollingTest() {
+        // Given
+        val dataEventRequest = EventsDataFactory.aValidFRDataEvent(
+                listOf(EventsDataFactory.aValidOBEventNotification1(OBVersion.v3_1_10)),
+                tppResource.tpp.registrationResponse.client_id
+        )
+        Assertions.assertThat(dataEventRequest).isNotNull
+
+        val adminAccessToken = EventNotificationRS().getClientCredentialsAdminAccessToken(tppResource.tpp).access_token
+        val eventsImported = EventNotificationRS().importDataEvent<FREventMessages>(dataEventRequest, adminAccessToken)
+        Assertions.assertThat(eventsImported).isNotNull
+        Assertions.assertThat(eventsImported.events.size).isGreaterThan(0)
+
+        val obEventPollingRequest = OBEventPolling1().returnImmediately(true)
+
+        // When
+        val obEventPollingResponse = EventNotificationRS().postAggregatedPolling<OBEventPollingResponse1>(
+                eventAggregatedPollingUrl,
+                obEventPollingRequest,
+                tppResource.tpp
+        )
+
+        // Then
+        Assertions.assertThat(obEventPollingResponse).isNotNull
+        Assertions.assertThat(obEventPollingResponse.sets.keys).contains(eventsImported.events[0].jti)
+        Assertions.assertThat(obEventPollingResponse.sets.values).contains(eventsImported.events[0].set)
+
+        // Finally
+        deleteImportedEvents(eventsImported, adminAccessToken)
+
+    }
+
+    fun shouldAcknowledgeEventTest() {
+        // Given
+        val dataEventRequest = EventsDataFactory.aValidFRDataEvent(
+                listOf(EventsDataFactory.aValidOBEventNotification1(OBVersion.v3_1_10)),
+                tppResource.tpp.registrationResponse.client_id
+        )
+
+        val adminAccessToken = EventNotificationRS().getClientCredentialsAdminAccessToken(tppResource.tpp).access_token
+        val eventsImported = EventNotificationRS().importDataEvent<FREventMessages>(dataEventRequest, adminAccessToken)
+        Assertions.assertThat(eventsImported).isNotNull
+        Assertions.assertThat(eventsImported.events.size).isGreaterThan(0)
+
+        val jtiList = eventsImported.events
+                .stream()
+                .map(FREventMessage::getJti)
+                .toList()
+
+        val obEventPollingRequest = OBEventPolling1()
+        obEventPollingRequest.ack(jtiList)
+
+        // When
+        val obEventPollingResponse = EventNotificationRS().postAggregatedPolling<OBEventPollingResponse1>(
+                eventAggregatedPollingUrl,
+                obEventPollingRequest,
+                tppResource.tpp
+        )
+
+        // Then
+        Assertions.assertThat(obEventPollingResponse).isNotNull
+        Assertions.assertThat(obEventPollingResponse.sets.keys).doesNotContainAnyElementsOf(jtiList)
+
+        // Finally
+        verifyNonexistentEvents(eventsImported, adminAccessToken)
+    }
+
+    fun shouldPollAndAcknowledgeEventTest() {
+        // Given
+        val obEventNotifications = listOf(
+                EventsDataFactory.aValidOBEventNotification1(OBVersion.v3_1_10),
+                EventsDataFactory.aValidOBEventNotification1(OBVersion.v3_1_10)
+        )
+        val dataEventRequest = EventsDataFactory.aValidFRDataEvent(obEventNotifications, tppResource.tpp.registrationResponse.client_id)
+
+        val adminAccessToken = EventNotificationRS().getClientCredentialsAdminAccessToken(tppResource.tpp).access_token
+        val eventsImported = EventNotificationRS().importDataEvent<FREventMessages>(dataEventRequest, adminAccessToken)
+        Assertions.assertThat(eventsImported).isNotNull
+        Assertions.assertThat(eventsImported.events.size).isGreaterThan(1)
+
+        val obEventPollingRequest = OBEventPolling1().returnImmediately(true)
+        obEventPollingRequest.ack(listOf(eventsImported.events[0].jti))
+
+        obEventPollingRequest.setErrs(
+                mapOf(
+                        eventsImported.events[1].jti to
+                                OBEventPolling1SetErrs().err("jwtIss").description("Issuer is invalid or could not be verified")
+                )
+        )
+
+        // When
+        val obEventPollingResponse = EventNotificationRS().postAggregatedPolling<OBEventPollingResponse1>(
+                eventAggregatedPollingUrl,
+                obEventPollingRequest,
+                tppResource.tpp
+        )
+
+        // Then
+        Assertions.assertThat(obEventPollingResponse).isNotNull
+        val jtiList = eventsImported.events
+                .stream()
+                .map(FREventMessage::getJti)
+                .toList()
+        Assertions.assertThat(obEventPollingResponse.sets.keys).doesNotContainAnyElementsOf(jtiList)
+
+        // Finally
+        deleteImportedEvents(eventsImported, adminAccessToken)
+    }
+
+    private fun deleteImportedEvents(eventsImported: FREventMessages, adminAccessToken: String) {
+        EventNotificationRS().deleteImportedEvents(eventsImported, adminAccessToken)
+        verifyNonexistentEvents(eventsImported, adminAccessToken)
+    }
+
+    private fun verifyNonexistentEvents(eventsImported: FREventMessages, adminAccessToken: String) {
+        val eventMessages = EventNotificationRS().exportEvents<FREventMessages>(
+                eventsImported.apiClientId,
+                adminAccessToken
+        )
+        Assertions.assertThat(eventMessages.events).doesNotContainAnyElementsOf(eventsImported.events)
+    }
+}

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/junit/v3_1_10/AggregatedPollingTest.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/junit/v3_1_10/AggregatedPollingTest.kt
@@ -1,0 +1,47 @@
+package com.forgerock.sapi.gateway.ob.uk.tests.functional.events.aggregatedpolling.junit.v3_1_10
+
+import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
+import com.forgerock.sapi.gateway.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.sapi.gateway.ob.uk.tests.functional.events.aggregatedpolling.api.v3_1_10.AggregatedPolling
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AggregatedPollingTest(val tppResource: CreateTppCallback.TppResource) {
+    lateinit var aggregatedPollingApi: AggregatedPolling
+
+    @BeforeEach
+    fun setUp() {
+        aggregatedPollingApi = AggregatedPolling(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+            type = "events",
+            apiVersion = "v3.1.10",
+            operations = ["EventAggregatedPolling"]
+    )
+    @Test
+    fun shouldInitialPollingTest_v3_1_10() {
+        aggregatedPollingApi.shouldInitialPollingTest()
+    }
+
+    @EnabledIfVersion(
+            type = "events",
+            apiVersion = "v3.1.10",
+            operations = ["EventAggregatedPolling"]
+    )
+    @Test
+    fun shouldAcknowledgeTest_v3_1_10() {
+        aggregatedPollingApi.shouldAcknowledgeEventTest()
+    }
+
+    @EnabledIfVersion(
+            type = "events",
+            apiVersion = "v3.1.10",
+            operations = ["EventAggregatedPolling"]
+    )
+    @Test
+    fun shouldPollAndAcknowledgeTest_v3_1_10() {
+        aggregatedPollingApi.shouldPollAndAcknowledgeEventTest()
+    }
+}


### PR DESCRIPTION
- Bumped commons bom version 2.0.3
- Added rs store datamodel 2.0.2 as new dependency
- Added aggregated polling functional test coverage (poll, acknowledge, poll and acknowledge)
- Added gradle events test task for v3.1.10

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1001