### PR TITLE
1134: Supporting tls_client_auth token_endpoint_auth_method

### DIFF
--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -63,5 +63,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-devops.gradle.kts
+++ b/gradle/profiles/profile-devops.gradle.kts
@@ -63,5 +63,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-fritss-itssdev.gradle.kts
+++ b/gradle/profiles/profile-fritss-itssdev.gradle.kts
@@ -63,5 +63,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-nightly.gradle.kts
+++ b/gradle/profiles/profile-nightly.gradle.kts
@@ -63,5 +63,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-ob-sandbox-v1.gradle.kts
+++ b/gradle/profiles/profile-ob-sandbox-v1.gradle.kts
@@ -64,5 +64,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-ob-sandbox-v2.gradle.kts
+++ b/gradle/profiles/profile-ob-sandbox-v2.gradle.kts
@@ -64,5 +64,6 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
+val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
@@ -31,7 +31,12 @@ val OB_TPP_EIDAS_SIGNING_KEY_PATH = System.getenv("eidasOBSealKey") ?: "./certs/
 val OB_TPP_EIDAS_SIGNING_PEM_PATH = System.getenv("eidasOBSealPem") ?: "./certs/OBSeal.pem"
 val OB_TPP_EIDAS_TRANSPORT_KEY_PATH = System.getenv("eidasOBWacKey") ?: "./certs/OBWac.key"
 val OB_TPP_EIDAS_TRANSPORT_PEM_PATH = System.getenv("eidasOBWacPem") ?: "./certs/OBWac.pem"
+val OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN: String? = System.getenv("eidasOBWacSubjectDN")
 
 val ISS_CLAIM_VALUE = System.getenv("obOrganisationId") + "/" + System.getenv("obSoftwareId")
 
 val REDIRECT_URI = System.getenv("redirectUri") ?: "https://www.google.co.uk"
+
+const val AUTH_METHOD_TLS_CLIENT = "tls_client_auth"
+const val AUTH_METHOD_PRIVATE_KEY_JWT = "private_key_jwt"
+val CLIENT_AUTH_METHOD = System.getenv("clientAuthMethod") ?: AUTH_METHOD_PRIVATE_KEY_JWT

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
@@ -6,27 +6,27 @@ import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_EIDAS_TRANSPORT
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.asDiscovery
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBConstants
-
 data class RegistrationRequest(
+        val software_statement: String,
         val iss: String = com.forgerock.sapi.gateway.ob.uk.framework.configuration.OB_SOFTWARE_ID,
         val exp: Long = (System.currentTimeMillis() / 1000) + 180,
         val grant_types: List<String> = asDiscovery.grant_types_supported,
         val id_token_signed_response_alg: String = "PS256",
         val redirect_uris: List<String> = listOf(REDIRECT_URI),
         val request_object_encryption_alg: String = "RSA-OAEP-256",
-        val request_object_encryption_enc: String? = asDiscovery.request_object_encryption_enc_values_supported[3],
+        val request_object_encryption_enc: String? = null,
         val request_object_signing_alg: String = "PS256",
         val response_types: List<String> = listOf("code id_token"),
         val scope: String = asDiscovery.scopes_supported.intersect(
-        listOf(
-            OBConstants.Scope.OPENID,
-            OBConstants.Scope.ACCOUNTS,
-            OBConstants.Scope.PAYMENTS,
-            OBConstants.Scope.FUNDS_CONFIRMATIONS,
-            OBConstants.Scope.EVENT_POLLING
-        )
-    ).joinToString(separator = " "),
-        val software_statement: String,
+            listOf(
+                OBConstants.Scope.OPENID,
+                OBConstants.Scope.ACCOUNTS,
+                OBConstants.Scope.PAYMENTS,
+                OBConstants.Scope.FUNDS_CONFIRMATIONS,
+                OBConstants.Scope.EVENT_POLLING
+            )
+        ).joinToString(separator = " "),
+
         val subject_type: String = "pairwise",
         val token_endpoint_auth_method: String = CLIENT_AUTH_METHOD,
         val token_endpoint_auth_signing_alg: String = "PS256",

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
@@ -1,5 +1,8 @@
 package com.forgerock.sapi.gateway.framework.data
 
+import com.forgerock.sapi.gateway.framework.configuration.AUTH_METHOD_TLS_CLIENT
+import com.forgerock.sapi.gateway.framework.configuration.CLIENT_AUTH_METHOD
+import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.asDiscovery
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBConstants
@@ -25,9 +28,9 @@ data class RegistrationRequest(
     ).joinToString(separator = " "),
         val software_statement: String,
         val subject_type: String = "pairwise",
-        val token_endpoint_auth_method: String = "private_key_jwt",
+        val token_endpoint_auth_method: String = CLIENT_AUTH_METHOD,
         val token_endpoint_auth_signing_alg: String = "PS256",
-        val tls_client_auth_subject_dn: String? = null
+        val tls_client_auth_subject_dn: String? = if (token_endpoint_auth_method == AUTH_METHOD_TLS_CLIENT) OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN else null
 )
 
 data class RegistrationResponse(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
@@ -102,7 +102,7 @@ data class Tpp(
         return Jwts.builder()
             .setHeaderParam("kid", signingKid)
             .setPayload(GsonUtils.gson.toJson(registrationRequest))
-            .signWith(signingKey, SignatureAlgorithm.forName(asDiscovery.request_object_signing_alg_values_supported[0]))
+            .signWith(signingKey, SignatureAlgorithm.forName(registrationRequest.request_object_signing_alg))
             .compact()
     }
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/Tpp.kt
@@ -1,6 +1,7 @@
 package com.forgerock.sapi.gateway.framework.data
 
 import com.forgerock.sapi.gateway.framework.cert.loadRsaPrivateKey
+import com.forgerock.sapi.gateway.framework.configuration.AUTH_METHOD_PRIVATE_KEY_JWT
 import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_EIDAS_SIGNING_KEY_PATH
 import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_OB_EIDAS_TEST_SIGNING_KID
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
@@ -20,7 +21,6 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
-import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.result.Result
 import com.nimbusds.jose.JOSEObjectType
@@ -164,23 +164,27 @@ data class Tpp(
     }
 
     fun getClientCredentialsAccessToken(scopes: String): AccessToken {
-        val requestParameters = ClientCredentialData(
-            sub = registrationResponse.client_id,
-            iss = registrationResponse.client_id,
-            aud = asDiscovery.issuer
-        )
-        val signedPayload = signPayload(requestParameters, signingKey, signingKid)
-        val body = listOf(
+        val body = mutableListOf(
+            "client_id" to registrationResponse.client_id,
             "grant_type" to GrantTypes.CLIENT_CREDENTIALS,
             "redirect_uri" to REDIRECT_URI,
-            "client_assertion_type" to Companion.CLIENT_ASSERTION_TYPE,
             "scope" to scopes,
-            "client_assertion" to signedPayload
         )
-        val (_, accessTokenResponse, result) = Fuel.post(asDiscovery.token_endpoint, parameters = body)
-            .authentication()
-            .basic(registrationResponse.client_id, registrationResponse.client_secret!!)
-            .responseObject<AccessToken>()
+
+        if (registrationResponse.token_endpoint_auth_method == AUTH_METHOD_PRIVATE_KEY_JWT) {
+            val requestParameters = ClientCredentialData(
+                sub = registrationResponse.client_id,
+                iss = registrationResponse.client_id,
+                aud = asDiscovery.issuer
+            )
+            val signedPayload = signPayload(requestParameters, signingKey, signingKid)
+            body.addAll(
+                listOf("client_assertion_type" to Companion.CLIENT_ASSERTION_TYPE,
+                       "client_assertion" to signedPayload)
+            )
+        }
+
+        val (_, accessTokenResponse, result) = Fuel.post(asDiscovery.token_endpoint, parameters = body).responseObject<AccessToken>()
         if (!accessTokenResponse.isSuccessful) throw AssertionError(
             "Could not get access token: \n" + result.component2()?.errorData?.toString(
                 Charsets.UTF_8


### PR DESCRIPTION
Changes applied to support tls_client_auth

- Adding clientAuthMethod configuration option to control the auth method used, defaulting this to private_key_jwt
- Adding eidasOBWacSubjectDN configuration which is required when doing tls_client_auth.
- Updating TPP DCR to support choosing the auth method based on the config
- Updating access_token requests to supply the client credentials using the configured auth method.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1134