### PR TITLE
1134: Removing eidasOBWacSubjectDN config

### DIFF
--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -63,6 +63,5 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-devops.gradle.kts
+++ b/gradle/profiles/profile-devops.gradle.kts
@@ -63,6 +63,5 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-fritss-itssdev.gradle.kts
+++ b/gradle/profiles/profile-fritss-itssdev.gradle.kts
@@ -63,6 +63,7 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")
+
+val clientAuthMethod by extra("tls_client_auth")

--- a/gradle/profiles/profile-nightly.gradle.kts
+++ b/gradle/profiles/profile-nightly.gradle.kts
@@ -63,6 +63,5 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-ob-sandbox-v1.gradle.kts
+++ b/gradle/profiles/profile-ob-sandbox-v1.gradle.kts
@@ -64,6 +64,5 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/gradle/profiles/profile-ob-sandbox-v2.gradle.kts
+++ b/gradle/profiles/profile-ob-sandbox-v2.gradle.kts
@@ -64,6 +64,5 @@ val eidasOBSealKey by extra("./certificates/OBSeal.key")
 val eidasOBSealPem by extra("./certificates/OBSeal.pem")
 val eidasOBWacKey by extra("./certificates/OBWac.key")
 val eidasOBWacPem by extra("./certificates/OBWac.pem")
-val eidasOBWacSubjectDN by extra("CN=0015800001041REAAY, OID.2.5.4.97=PSDGB-OB-Unknown0015800001041REAAY, O=FORGEROCK LIMITED, C=GB")
 
 val redirectUri by extra("https://www.google.co.uk")

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
@@ -31,7 +31,6 @@ val OB_TPP_EIDAS_SIGNING_KEY_PATH = System.getenv("eidasOBSealKey") ?: "./certs/
 val OB_TPP_EIDAS_SIGNING_PEM_PATH = System.getenv("eidasOBSealPem") ?: "./certs/OBSeal.pem"
 val OB_TPP_EIDAS_TRANSPORT_KEY_PATH = System.getenv("eidasOBWacKey") ?: "./certs/OBWac.key"
 val OB_TPP_EIDAS_TRANSPORT_PEM_PATH = System.getenv("eidasOBWacPem") ?: "./certs/OBWac.pem"
-val OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN: String? = System.getenv("eidasOBWacSubjectDN")
 
 val ISS_CLAIM_VALUE = System.getenv("obOrganisationId") + "/" + System.getenv("obSoftwareId")
 

--- a/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
@@ -1,8 +1,6 @@
 package com.forgerock.sapi.gateway.framework.data
 
-import com.forgerock.sapi.gateway.framework.configuration.AUTH_METHOD_TLS_CLIENT
 import com.forgerock.sapi.gateway.framework.configuration.CLIENT_AUTH_METHOD
-import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.asDiscovery
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBConstants
@@ -30,7 +28,7 @@ data class RegistrationRequest(
         val subject_type: String = "pairwise",
         val token_endpoint_auth_method: String = CLIENT_AUTH_METHOD,
         val token_endpoint_auth_signing_alg: String = "PS256",
-        val tls_client_auth_subject_dn: String? = if (token_endpoint_auth_method == AUTH_METHOD_TLS_CLIENT) OB_TPP_EIDAS_TRANSPORT_CERT_SUBJECT_DN else null
+        val tls_client_auth_subject_dn: String
 )
 
 data class RegistrationResponse(

--- a/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/registration/Registration.kt
+++ b/src/test/kotlin/com/forgerock/sapi/gateway/ob/uk/support/registration/Registration.kt
@@ -1,12 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.support.registration
 
-import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_EIDAS_SIGNING_KEY_PATH
-import com.forgerock.sapi.gateway.framework.configuration.OB_TPP_OB_EIDAS_TEST_SIGNING_KID
-import com.forgerock.sapi.gateway.framework.data.RegistrationRequest
 import com.forgerock.sapi.gateway.framework.data.RegistrationResponse
 import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
-import com.forgerock.sapi.gateway.framework.utils.FileUtils
-import com.forgerock.sapi.gateway.framework.utils.GsonUtils
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.asDiscovery
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
@@ -15,8 +10,6 @@ import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.result.Result
-import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.SignatureAlgorithm
 
 data class UserRegistrationRequest(val user: User) {
     constructor(userName: String, password: String, uid: String) : this(User(userName, password, uid))
@@ -47,31 +40,4 @@ fun registerTpp(signedRegistrationRequest: String): RegistrationResponse {
         )
     }
     return result.get()
-}
-
-@Deprecated("To delete pre-eidas resources")
-//fun signRegistrationRequest(): Pair<String, RegistrationRequest> {
-//    val ssa = FileUtils().getStringContent("OB_TPP_PRE_EIDAS_SSA_PATH")
-//    val registrationRequest = RegistrationRequest(software_statement = ssa)
-//    val privateKey = FileUtils().getStringContent("OB_TPP_PRE_EIDAS_SIGNING_KEY")
-//    val key = loadRsaPrivateKey(privateKey)
-//    val signedRegistrationRequest = Jwts.builder()
-//        .setHeaderParam("kid", OB_TPP_PRE_EIDAS_SIGNING_KID)
-//        .setPayload(GsonUtils.gson.toJson(registrationRequest))
-//        .signWith(key, SignatureAlgorithm.forName(asDiscovery.request_object_signing_alg_values_supported[0]))
-//        .compact()
-//    return Pair(signedRegistrationRequest, registrationRequest)
-//}
-
-fun signOBEidasRegistrationRequest(): Pair<String, RegistrationRequest> {
-    val ssa = FileUtils().getStringContent("OB_TPP_EIDAS_SSA_PATH")
-    val registrationRequest = RegistrationRequest(software_statement = ssa)
-    val privateKey = FileUtils().getStringContent(OB_TPP_EIDAS_SIGNING_KEY_PATH)
-    val key = com.forgerock.sapi.gateway.ob.uk.support.getRsaPrivateKey(privateKey)
-    val signedRegistrationRequest = Jwts.builder()
-        .setHeaderParam("kid", OB_TPP_OB_EIDAS_TEST_SIGNING_KID)
-        .setPayload(GsonUtils.gson.toJson(registrationRequest))
-        .signWith(key, SignatureAlgorithm.forName(asDiscovery.request_object_signing_alg_values_supported[0]))
-        .compact()
-    return Pair(signedRegistrationRequest, registrationRequest)
 }


### PR DESCRIPTION
eidasOBWacSubjectDN configuration has been removed in favour of extracting the value from the TPP's OBWac cert, this makes the config simpler and removes the possibility of misconfiguration.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1134