### PR TITLE
1148: prepare release 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,9 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
  */
 // project version
 // pom artifact version used when the built artifact is published
-version = "2.0.2"
+version = "2.1.0"
 // Test jar library version used in the task 'generateTestJar'
-val release = "2.0.2"
+val release = "2.1.0"
 val jaxbVersion = "2.2.11"
 
 plugins {
@@ -75,7 +75,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:2.0.4-SNAPSHOT"))
+    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:2.1.0"))
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-shared")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel")


### PR DESCRIPTION
- Updated version to 2.1.0
- Bumped common version 2.1.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1148