### PR TITLE
1175 add localDate serializer and deserializer to core

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/http/fuel/FuelInitialiser.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/http/fuel/FuelInitialiser.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.datatype.joda.JodaModule
+import com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.forgerock.sapi.gateway.framework.configuration.*
 import com.forgerock.sapi.gateway.framework.data.Tpp
@@ -29,7 +30,9 @@ import io.r2.simplepemkeystore.SimplePemKeyStoreProvider
 import org.apache.http.ssl.SSLContextBuilder
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import org.joda.time.LocalDate
 import org.joda.time.format.ISODateTimeFormat
+import uk.org.openbanking.jackson.LocalDateDeserializer
 import java.io.InputStream
 import java.lang.reflect.Type
 import java.security.KeyStore
@@ -72,6 +75,8 @@ class DateTimeSerializer : StdSerializer<DateTime>(DateTime::class.java) {
 val serializers: SimpleModule = SimpleModule("CustomSerializer")
     .addDeserializer(DateTime::class.java, DateTimeDeserializer())
     .addSerializer(DateTime::class.java, DateTimeSerializer())
+    .addSerializer(LocalDate::class.java, LocalDateSerializer())
+    .addDeserializer(LocalDate::class.java, LocalDateDeserializer())
 
 val defaultMapper: ObjectMapper = ObjectMapper().registerKotlinModule()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)


### PR DESCRIPTION
- Added LocalDate serializer in custom simple module in core
- Added LocalDate deserializer in custom simple module in core

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1175

Customer info defines the field BirthDate as LocalDate type, so that needs to be parsed with a specific serialiser / Deserialiser for LocalDate types to be formatted properly and avoid jackson invalid format errors when jackson parse the customer info object from the response.

The serialiser and deserialiser has been implemented and they live in Common project [here](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/tree/master/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson)

```java
// FuelInitialiser.kt#L80
val serializers: SimpleModule = SimpleModule("CustomSerializer")
    .addDeserializer(DateTime::class.java, DateTimeDeserializer())
    .addSerializer(DateTime::class.java, DateTimeSerializer())
    .addSerializer(LocalDate::class.java, LocalDateSerializer())
    .addDeserializer(LocalDate::class.java, LocalDateDeserializer())
```
Apply the solution [here](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-functional-tests/blob/908ba7fa46474f6913e21bc7df3e6b9d66b52b7b/src/main/kotlin/com/forgerock/sapi/gateway/framework/http/fuel/FuelInitialiser.kt#L74) to support serialise and deserialise LocalDate types in the core mapper joda module.
