### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }} name=${{ env.SERVICE_NAME }}
-          docker tag ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
-          docker push ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=${{ env.GIT_SHA_SHORT }}
+          make docker tag=${{ env.GIT_SHA_SHORT }} name=${{ env.SERVICE_NAME }}
           docker tag ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
-          docker push --all-tags ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}
+          docker push ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }} name=${{ env.SERVICE_NAME }}
-          docker tag ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
-          docker push ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
+          docker tag ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
+          docker push ${{ secrets.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,19 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
       
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}
+          docker tag ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
+          docker push --all-tags ${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,14 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
       
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build Docker Image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,14 +19,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
       
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build Docker Image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,24 +19,28 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
       
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.PR_NUMBER }}
-      
+  test:
+    runs-on: ubuntu-latest
+    name: Test Image
+    needs: build
+    steps:        
       - name: 'Run Functional Tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v SPEC_IMAGE=${{ env.SERVICE_NAME }} -v TAG=${{ env.PR_NUMBER }} -v TEST_TASK=${{ env.TEST_TASK }}'
+          args: '-v IMAGE_REPO=securebanking/pr/${{ env.SERVICE_NAME }} -v TAG=${{ env.PR_NUMBER }} -v TEST_TASK=${{ env.TEST_TASK }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dev-functional-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,19 @@ jobs:
         with:
           ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         id: gcloud_auth
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         id: gcloud_sdk
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       - name: Set up docker auth
         id: gcloud_docker_auth
         run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: prepare context
         id: prepare_context
@@ -65,9 +65,9 @@ jobs:
         id: build_docker
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }}
-          docker tag eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
-          docker tag eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ inputs.release_version_number }}
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}
+          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/pr/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
+          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ inputs.release_version_number }}
+          docker push --all-tags ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}
 
   release_draft:
     name: Call publish release draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Build Docker Image
         id: build_docker
         run: |
-          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }}
-          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/pr/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
+          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }} name=${{ env.SERVICE_NAME }}
+          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
           docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ inputs.release_version_number }}
           docker push --all-tags ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build Docker Image
         id: build_docker
         run: |
-          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }} name=${{ env.SERVICE_NAME }}
+          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ vars.GAR_RELEASE_REPO }} name=${{ env.SERVICE_NAME }}
           docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:latest
           docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/tests/${{ env.SERVICE_NAME}}:${{ inputs.release_version_number }}
           docker push --all-tags ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ env.SERVICE_NAME}}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-name := /pr/uk-functional-tests
+name := pr/uk-functional-tests
 repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 tag  := latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-name := uk-functional-tests
-repo := sbat-gcr-develop
+name := /pr/uk-functional-tests
+repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 tag  := latest
 
 docker:
-	docker build -t eu.gcr.io/${repo}/securebanking/tests/${name}:${tag} .
-	docker push eu.gcr.io/${repo}/securebanking/tests/${name}:${tag}
+	docker build -t ${repo}/securebanking/${name}:${tag} .
+	docker push ${repo}/securebanking/${name}:${tag}


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202