### PR TITLE
1245: Removing trailing slash from RCS Decision API calls

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
@@ -8,6 +8,8 @@ val IG_SERVER = System.getenv("igServer") ?: "https://sapig.dev.forgerock.financ
 // mtls is a subdomain of the gateway domain
 val MTLS_SERVER = IG_SERVER.replace("https://", "https://mtls.")
 
+val RCS_DECISION_API_URI = "$IG_SERVER/rcs/api/consent/decision"
+
 val TRUSTSTORE_PATH = System.getenv("truststorePath") ?: "/com/forgerock/sapi/gateway/ob/uk/truststore.jks"
 val TRUSTSTORE_PASSWORD = System.getenv("truststorePassword") ?: "changeit"
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountAS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountAS.kt
@@ -1,7 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.support.account
 
 import com.forgerock.sapi.gateway.framework.configuration.AM_COOKIE_NAME
-import com.forgerock.sapi.gateway.framework.configuration.IG_SERVER
+import com.forgerock.sapi.gateway.framework.configuration.RCS_DECISION_API_URI
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
 import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.data.RegistrationResponse
@@ -79,7 +79,7 @@ class AccountAS : GeneralAS() {
         cookie: String
     ): SendConsentDecisionResponseBody {
         val body = SendConsentDecisionRequestBody(consentRequest, "Authorised", consentedAccount.toList())
-        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/decision/")
+        val (_, response, result) = Fuel.post(RCS_DECISION_API_URI)
                                         .header("Cookie", cookie)
                                         .jsonBody(body)
                                         .responseObject<SendConsentDecisionResponseBody>()

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationAS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationAS.kt
@@ -1,7 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.support.funds
 
 import com.forgerock.sapi.gateway.framework.configuration.AM_COOKIE_NAME
-import com.forgerock.sapi.gateway.framework.configuration.IG_SERVER
+import com.forgerock.sapi.gateway.framework.configuration.RCS_DECISION_API_URI
 import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.data.RegistrationResponse
 import com.forgerock.sapi.gateway.framework.data.Tpp
@@ -83,7 +83,7 @@ class FundsConfirmationAS : GeneralAS() {
             cookie: String
     ): SendConsentDecisionResponseBody {
         val body = SendConsentDecisionRequestBody(consentRequest, decision, consentedAccount)
-        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/decision/")
+        val (_, response, result) = Fuel.post(RCS_DECISION_API_URI)
                 .header("Cookie", cookie)
                 .jsonBody(body)
                 .responseObject<SendConsentDecisionResponseBody>()

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/general/GeneralAS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/general/GeneralAS.kt
@@ -2,7 +2,6 @@ package com.forgerock.sapi.gateway.ob.uk.support.general
 
 import com.forgerock.sapi.gateway.framework.configuration.AUTH_METHOD_PRIVATE_KEY_JWT
 import com.forgerock.sapi.gateway.framework.configuration.IG_SERVER
-//import com.forgerock.sapi.gateway.framework.configuration.PLATFORM_SERVER
 import com.forgerock.sapi.gateway.framework.configuration.REDIRECT_URI
 import com.forgerock.sapi.gateway.framework.data.*
 import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
@@ -128,7 +127,7 @@ open class GeneralAS {
     }
 
     protected fun getConsentDetails(consentRequest: String, cookie: String): String {
-        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/details/")
+        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/details")
             .header("Cookie", cookie)
             .body(consentRequest)
             .header("Content-Type", "application/jwt")

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentAS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentAS.kt
@@ -1,7 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.support.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.AM_COOKIE_NAME
-import com.forgerock.sapi.gateway.framework.configuration.IG_SERVER
+import com.forgerock.sapi.gateway.framework.configuration.RCS_DECISION_API_URI
 import com.forgerock.sapi.gateway.framework.data.AccessToken
 import com.forgerock.sapi.gateway.framework.data.RegistrationResponse
 import com.forgerock.sapi.gateway.framework.data.Tpp
@@ -102,7 +102,7 @@ class PaymentAS : GeneralAS() {
         cookie: String
     ): SendConsentDecisionResponseBody {
         val body = SendConsentDecisionRequestBody(consentRequest, decision, consentedAccount, isDebtorAccountProvided)
-        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/decision/")
+        val (_, response, result) = Fuel.post(RCS_DECISION_API_URI)
             .header("Cookie", cookie)
             .jsonBody(body)
             .responseObject<SendConsentDecisionResponseBody>()


### PR DESCRIPTION
Spring Boot 3 is not mapping URIs with trailing slashes to the controller, the trailing slash is incorrect and should be removed.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1245