### PR TITLE
1479: Stop setting DebtorAccount.Name for non-VRP payments

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationConsentFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationConsentFactory.kt
@@ -20,10 +20,9 @@ class FundsConfirmationConsentFactory {
                                     .expirationDateTime(DateTime.now().plusMonths(5).withZone(DateTimeZone.UTC))
                                     .debtorAccount(
                                         OBFundsConfirmationConsent1DataDebtorAccount()
-                                                    .identification(debtorAccount?.Identification)
-                                                    .name(debtorAccount?.Name)
-                                                    .schemeName(debtorAccount?.SchemeName)
-                                                    .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                                                    .identification(debtorAccount.Identification)
+                                                    .schemeName(debtorAccount.SchemeName)
+                                                    .secondaryIdentification(debtorAccount.SecondaryIdentification)
                                     )
                     )
         }

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -75,10 +75,9 @@ class CreateDomesticPayment(
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
         val result = submitPayment(consentRequest)
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -73,7 +73,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
         assertThat(consentResponse2.risk).isNotNull()
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
     }
 
     fun createDomesticPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
@@ -102,10 +102,9 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createDomesticPaymentsConsent(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -6,17 +6,24 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.framework.http.fuel.defaultMapper
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType
 import com.forgerock.sapi.gateway.ob.uk.framework.consent.ConsentFactoryRegistryHolder
-import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBWriteDomesticConsent4Factory
 import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBWriteDomesticScheduledConsent4Factory
 import com.forgerock.sapi.gateway.ob.uk.framework.constants.INVALID_CONSENT_ID
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
-import com.forgerock.sapi.gateway.ob.uk.support.payment.*
+import com.forgerock.sapi.gateway.ob.uk.support.payment.BadJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.InvalidKidJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
+import com.forgerock.sapi.gateway.ob.uk.support.payment.PsuData
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.payment.*
-import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2Data
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5
 import java.util.UUID
 
 class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
@@ -50,7 +57,6 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
                 .identification(debtorAccount.Identification)
-                .name(debtorAccount.Name)
                 .schemeName(debtorAccount.SchemeName)
                 .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -12,7 +12,12 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.framework.consent.ConsentFactoryRegistryHolder
 import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBWriteDomesticScheduledConsent4Factory
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
-import com.forgerock.sapi.gateway.ob.uk.support.payment.*
+import com.forgerock.sapi.gateway.ob.uk.support.payment.BadJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.InvalidKidJwsSignatureProducer
+import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentAS
+import com.forgerock.sapi.gateway.ob.uk.support.payment.PsuData
+import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
@@ -20,8 +25,7 @@ import org.joda.time.DateTime
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5
-import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
-import java.util.*
+import java.util.UUID
 
 class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
@@ -77,7 +81,7 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
         assertThat(consentResponse2.risk).isNotNull()
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
     }
 
     fun createDomesticScheduledPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
@@ -106,10 +110,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createDomesticScheduledPaymentConsent(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -53,10 +53,9 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
                 OBWriteDomesticStandingOrder3DataInitiationDebtorAccount()
-                        .identification(debtorAccount?.Identification)
-                        .name(debtorAccount?.Name)
-                        .schemeName(debtorAccount?.SchemeName)
-                        .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                        .identification(debtorAccount.Identification)
+                        .schemeName(debtorAccount.SchemeName)
+                        .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
         // When
         val result = submitStandingOrder(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -104,10 +104,9 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomesticStandingOrder3DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createDomesticStandingOrderConsent(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -50,10 +50,9 @@ class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: Create
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
         val consent = createFilePaymentConsent(consentRequest)
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -79,10 +79,9 @@ class CreateInternationalPayment(
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         // When

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -78,7 +78,7 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
         assertThat(consentResponse2.risk).isNotNull()
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
     }
 
     fun createInternationalPaymentsConsents_NoIdempotencyKey_throwsBadRequestTest() {
@@ -107,10 +107,9 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createInternationalPaymentConsent(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -84,10 +84,9 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         // When

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -81,7 +81,7 @@ class CreateInternationalScheduledPaymentsConsents(
         Assertions.assertThat(consentResponse2.data.status.toString()).`is`(Status.consentCondition)
         assertThat(consentResponse2.risk).isNotNull()
 
-        assertThat(consentResponse1.data.consentId).equals(consentResponse2.data.consentId)
+        assertThat(consentResponse1.data.consentId).isEqualTo(consentResponse2.data.consentId)
 
     }
 
@@ -110,10 +110,9 @@ class CreateInternationalScheduledPaymentsConsents(
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomestic2DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createInternationalScheduledPaymentConsent(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
@@ -80,10 +80,9 @@ class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: 
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
                 OBWriteDomesticStandingOrder3DataInitiationDebtorAccount()
-                        .identification(debtorAccount?.Identification)
-                        .name(debtorAccount?.Name)
-                        .schemeName(debtorAccount?.SchemeName)
-                        .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                        .identification(debtorAccount.Identification)
+                        .schemeName(debtorAccount.SchemeName)
+                        .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
         // When
         val result = submitStandingOrder(consentRequest)

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
@@ -91,10 +91,9 @@ class CreateInternationalStandingOrderConsents(val version: OBVersion, val tppRe
         val debtorAccount = PsuData().getDebtorAccount()
         consentRequest.data.initiation.debtorAccount(
             OBWriteDomesticStandingOrder3DataInitiationDebtorAccount()
-                .identification(debtorAccount?.Identification)
-                .name(debtorAccount?.Name)
-                .schemeName(debtorAccount?.SchemeName)
-                .secondaryIdentification(debtorAccount?.SecondaryIdentification)
+                .identification(debtorAccount.Identification)
+                .schemeName(debtorAccount.SchemeName)
+                .secondaryIdentification(debtorAccount.SecondaryIdentification)
         )
 
         val consent = createInternationalStandingOrderConsent(consentRequest)


### PR DESCRIPTION
DebtorAccount.Name for non-VRP payment submissions is an optional field. No longer settings this field to reproduce the bug in the linked issue.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1479