### PR TITLE
1477: Fix imports for v3 datamodel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     xjc("com.sun.xml.bind:jaxb-xjc:${jaxbVersion}")
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:3.1.0"))
+    implementation(platform("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-bom:4.0.0-SNAPSHOT"))
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-shared")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-obie-datamodel")
     implementation("com.forgerock.sapi.gateway:secure-api-gateway-ob-uk-common-datamodel")

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBDomesticVRPConsentRequestFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBDomesticVRPConsentRequestFactory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequestMandatoryFields
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticConsent4Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticConsent4Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 /**

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticScheduledConsent4Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticScheduledConsent4Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
 /**

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticStandingOrderConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteDomesticStandingOrderConsent5Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5MandatoryFields
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalConsent5Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalScheduledConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalScheduledConsent5Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalStandingOrderConsent6Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/DefaultOBWriteInternationalStandingOrderConsent6Factory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
 import com.forgerock.sapi.gateway.framework.configuration.requirePaymentContextCode
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6MandatoryFields
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBDomesticVRPConsentRequestFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBDomesticVRPConsentRequestFactory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
 
 /**
  * Factory that creates OBDomesticVRPConsentRequest objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticConsent4Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticConsent4Factory.kt
@@ -1,7 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
 
 /**
  * Factory that creates OBWriteDomesticConsent4 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticScheduledConsent4Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticScheduledConsent4Factory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4
 
 /**
  * Factory that creates OBWriteDomesticScheduledConsent4 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticStandingOrderConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteDomesticStandingOrderConsent5Factory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5
 
 /**
  * Factory that creates OBWriteDomesticStandingOrderConsent5 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalConsent5Factory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5
 
 /**
  * Factory that creates OBWriteInternationalConsent5 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalScheduledConsent5Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalScheduledConsent5Factory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5
 
 /**
  * Factory that creates OBWriteInternationalScheduledConsent5 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalStandingOrderConsent6Factory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/framework/consent/payment/OBWriteInternationalStandingOrderConsent6Factory.kt
@@ -1,6 +1,6 @@
 package com.forgerock.sapi.gateway.ob.uk.framework.consent.payment
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6
 
 /**
  * Factory that creates OBWriteInternationalStandingOrderConsent6 objects

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountFactory.kt
@@ -1,10 +1,10 @@
 package com.forgerock.sapi.gateway.ob.uk.support.account
 
 import com.forgerock.sapi.gateway.ob.uk.support.general.GeneralFactory.Companion.urlSubstituted
-import uk.org.openbanking.datamodel.account.OBReadConsent1
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data
-import uk.org.openbanking.datamodel.account.OBRisk2
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data
+import uk.org.openbanking.datamodel.v3.account.OBRisk2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 /**
  * Generate common OB account data and URLs

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountRS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/account/AccountRS.kt
@@ -8,7 +8,7 @@ import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.ResponseResultOf
 import com.github.kittinunf.fuel.core.isSuccessful
-import uk.org.openbanking.datamodel.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
 
 const val HTTP_STATUS_CODE_NO_CONTENT = 204
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/discovery/RsDiscovery.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/discovery/RsDiscovery.kt
@@ -5,7 +5,7 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.gson.gsonDeserializer
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.memberProperties
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventNotificationRS.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventNotificationRS.kt
@@ -8,7 +8,7 @@ import com.forgerock.sapi.gateway.framework.http.fuel.responseObject
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.FREventMessages
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.isSuccessful
-import uk.org.openbanking.datamodel.event.OBEventPolling1
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1
 
 const val EVENT_ADMIN_API_SCOPES = "openid payments accounts fundsconfirmations"
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventsDataFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/event/EventsDataFactory.kt
@@ -1,7 +1,7 @@
 package com.forgerock.sapi.gateway.ob.uk.support.event
 
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.event.*
+import uk.org.openbanking.datamodel.v3.event.*
 import java.net.URI
 import java.util.UUID
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationConsentFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationConsentFactory.kt
@@ -4,9 +4,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.general.GeneralFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PsuData
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1Data
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1DataDebtorAccount
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1Data
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1DataDebtorAccount
 
 class FundsConfirmationConsentFactory {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/funds/FundsConfirmationFactory.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.support.funds
 
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1Data
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1DataInstructedAmount
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1Data
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1DataInstructedAmount
 
 class FundsConfirmationFactory {
     companion object {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentFactory.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/support/payment/PaymentFactory.kt
@@ -4,9 +4,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.general.GeneralFactory.Companion
 import com.google.common.base.Preconditions
 import org.apache.commons.io.FileUtils
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1
-import uk.org.openbanking.datamodel.payment.*
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation
+import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1
+import uk.org.openbanking.datamodel.v3.payment.*
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInitiation
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory
 import java.io.File
 import java.io.StringReader

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/AccountAccessConsentApi.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/AccountAccessConsentApi.kt
@@ -1,8 +1,8 @@
 package com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.consents
 
 import com.forgerock.sapi.gateway.framework.data.AccessToken
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1
 
 interface AccountAccessConsentApi {
     fun createConsent(permissions: List<OBExternalPermissions1Code>): OBReadConsentResponse1

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
@@ -15,8 +15,8 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.consents.AccountAccessConsentApi
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1
 
 class AccountAccessConsent(val version: OBVersion, val tppResource: CreateTppCallback.TppResource): AccountAccessConsentApi {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/accounts/api/v3_1_8/GetAccount.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/accounts/api/v3_1_8/GetAccount.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
 
 class GetAccount(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/accounts/api/v3_1_8/GetAccounts.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/accounts/api/v3_1_8/GetAccounts.kt
@@ -8,8 +8,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
 
 class GetAccounts(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountsTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/balances/api/v3_1_8/GetAccountBalances.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/balances/api/v3_1_8/GetAccountBalances.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadBalance1
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1
 
 class GetAccountBalances(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountBalancesTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/balances/api/v3_1_8/GetBalances.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/balances/api/v3_1_8/GetBalances.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadBalance1
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1
 
 class GetBalances(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetBalancesTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/beneficiaries/api/v3_1_8/GetAccountBeneficiaries.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/beneficiaries/api/v3_1_8/GetAccountBeneficiaries.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetAccountBeneficiaries(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountBeneficiariesTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/beneficiaries/api/v3_1_8/GetBeneficiaries.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/beneficiaries/api/v3_1_8/GetBeneficiaries.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetBeneficiaries(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetBeneficiariesTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/direct/debits/api/v3_1_8/GetAccountDirectDebits.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/direct/debits/api/v3_1_8/GetAccountDirectDebits.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2
 
 class GetAccountDirectDebits(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountDirectDebitsTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/direct/debits/api/v3_1_8/GetDirectDebits.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/direct/debits/api/v3_1_8/GetDirectDebits.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2
 
 class GetDirectDebits(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetDirectDebitsTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/offers/api/v3_1_8/GetAccountOffers.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/offers/api/v3_1_8/GetAccountOffers.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetAccountOffers(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountOffersTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/offers/api/v3_1_8/GetOffers.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/offers/api/v3_1_8/GetOffers.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetOffers(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource)  {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetAccountParties.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetAccountParties.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetAccountParties(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountPartiesTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetAccountParty.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetAccountParty.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetAccountParty(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetParty.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/parties/api/v3_1_8/GetParty.kt
@@ -8,8 +8,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetParty(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetPartyTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/products/api/v3_1_8/GetAccountProduct.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/products/api/v3_1_8/GetAccountProduct.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadProduct2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2
 
 class GetAccountProduct(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetAccountProductTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/products/api/v3_1_8/GetProducts.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/products/api/v3_1_8/GetProducts.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.*
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.*
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetProducts(version: OBVersion, tppResource: CreateTppCallback.TppResource): BaseAccountApi3_1_8(version, tppResource) {
     fun shouldGetProductsTest() {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/scheduled/payments/api/v3_1_8/GetAccountScheduledPayments.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/scheduled/payments/api/v3_1_8/GetAccountScheduledPayments.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3
 
 class GetAccountScheduledPayments(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/scheduled/payments/api/v3_1_8/GetScheduledPayments.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/scheduled/payments/api/v3_1_8/GetScheduledPayments.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3
 
 class GetScheduledPayments(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/standing/orders/api/v3_1_8/GetAccountStandingOrders.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/standing/orders/api/v3_1_8/GetAccountStandingOrders.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6
 
 class GetAccountStandingOrders(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/standing/orders/api/v3_1_8/GetStandingOrders.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/standing/orders/api/v3_1_8/GetStandingOrders.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6
 
 class GetStandingOrders(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatement.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatement.kt
@@ -7,9 +7,9 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadAccount6
-import uk.org.openbanking.datamodel.account.OBReadStatement2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2
 
 class GetAccountStatement(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatementFile.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatementFile.kt
@@ -7,9 +7,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
 import com.github.kittinunf.fuel.core.FuelError
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadAccount6
-import uk.org.openbanking.datamodel.account.OBReadStatement2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2
 
 class GetAccountStatementFile(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatementTransactions.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatementTransactions.kt
@@ -7,10 +7,10 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.account.OBReadAccount6
-import uk.org.openbanking.datamodel.account.OBReadStatement2
-import uk.org.openbanking.datamodel.account.OBReadTransaction6
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
 
 class GetAccountStatementTransactions(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatements.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetAccountStatements.kt
@@ -7,9 +7,9 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadAccount6
-import uk.org.openbanking.datamodel.account.OBReadStatement2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2
 
 class GetAccountStatements(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetStatements.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/statements/api/v3_1_8/GetStatements.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadStatement2
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2
 
 class GetStatements(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/transactions/api/v3_1_8/GetAccountTransactions.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/transactions/api/v3_1_8/GetAccountTransactions.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.account.AccountFactory
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadTransaction6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6
 
 class GetAccountTransactions(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/transactions/api/v3_1_8/GetTransactions.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/account/transactions/api/v3_1_8/GetTransactions.kt
@@ -7,8 +7,8 @@ import com.forgerock.sapi.gateway.framework.extensions.junit.CreateTppCallback
 import com.forgerock.sapi.gateway.ob.uk.support.account.AccountRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.account.access.BaseAccountApi3_1_8
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadTransaction6
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6
 
 class GetTransactions(version: OBVersion, tppResource: CreateTppCallback.TppResource) :
     BaseAccountApi3_1_8(version, tppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/api/v3_1_10/AggregatedPolling.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/events/aggregatedpolling/api/v3_1_10/AggregatedPolling.kt
@@ -7,10 +7,10 @@ import com.forgerock.sapi.gateway.ob.uk.support.event.EventNotificationRS
 import com.forgerock.sapi.gateway.ob.uk.support.event.EventsDataFactory
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.event.OBEventNotification1
-import uk.org.openbanking.datamodel.event.OBEventPolling1
-import uk.org.openbanking.datamodel.event.OBEventPolling1SetErrsValue
-import uk.org.openbanking.datamodel.event.OBEventPollingResponse1
+import uk.org.openbanking.datamodel.v3.event.OBEventNotification1
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1SetErrsValue
+import uk.org.openbanking.datamodel.v3.event.OBEventPollingResponse1
 import kotlin.streams.toList
 
 class AggregatedPolling(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/funds/api/v3_1_10/FundsConfirmations.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/funds/api/v3_1_10/FundsConfirmations.kt
@@ -20,8 +20,8 @@ import org.apache.http.entity.ContentType
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1
 
 class FundsConfirmations(
         val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/funds/consents/api/v3_1_10/FundsConfirmationConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/funds/consents/api/v3_1_10/FundsConfirmationConsents.kt
@@ -16,10 +16,10 @@ import com.forgerock.sapi.gateway.ob.uk.support.funds.FundsConfirmationConsentFa
 import com.forgerock.sapi.gateway.ob.uk.support.funds.FundsConfirmationRS
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1
 
 class FundsConfirmationConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -14,7 +14,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.paymen
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.util.UUID
 
 class CreateDomesticPayment(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -15,8 +15,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForA
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5
 
 class GetDomesticPayment(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDetails.kt
@@ -9,7 +9,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class GetDomesticPaymentDetails(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -16,9 +16,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5
 import java.util.*
 
 class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -11,7 +11,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4
 
 class GetDomesticPaymentsConsentFundsConfirmation(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -18,12 +18,12 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.schedu
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2Data
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2Data
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5
 import java.util.UUID
 
 class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -15,8 +15,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForA
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5
 
 class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDetails.kt
@@ -9,7 +9,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
 class GetDomesticScheduledPaymentDetails(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -22,9 +22,9 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5
 import java.util.UUID
 
 class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -19,7 +19,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standi
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.util.UUID
 
 class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -15,8 +15,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForA
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6
 
 class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDetails.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 
 class GetDomesticStandingOrderDetails(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -17,9 +17,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6
 import java.util.*
 
 class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -18,7 +18,7 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Headers
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.vrp.*
+import uk.org.openbanking.datamodel.v3.vrp.*
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpCommonTestDataFactory
 import java.math.BigDecimal
 import java.util.UUID

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrp.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrp.kt
@@ -16,8 +16,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponse
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponse
 
 class GetDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponse
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponse
 
 class GetDomesticVrpDetails(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsents.kt
@@ -13,9 +13,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.vrp.OBCashAccountDebtorWithName
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse
+import uk.org.openbanking.datamodel.v3.vrp.OBCashAccountDebtorWithName
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse
 import java.util.*
 
 class CreateDomesticVrpConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsentsFundsConfirmation.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/CreateDomesticVrpConsentsFundsConfirmation.kt
@@ -13,12 +13,12 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse
-import uk.org.openbanking.datamodel.vrp.OBPAFundsAvailableResult1FundsAvailable
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationResponse
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse
+import uk.org.openbanking.datamodel.v3.vrp.OBPAFundsAvailableResult1FundsAvailable
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequest
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequestData
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationResponse
 
 class CreateDomesticVrpConsentsFundsConfirmation(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/domestic/vrp/consents/api/v3_1_10/GetDomesticVrpConsents.kt
@@ -10,8 +10,8 @@ import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBDomesticVRPC
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PsuData
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.vrp.OBCashAccountDebtorWithName
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest
+import uk.org.openbanking.datamodel.v3.vrp.OBCashAccountDebtorWithName
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest
 
 class GetDomesticVrpConsents(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/CreateFilePayment.kt
@@ -12,7 +12,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.file.payments.c
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.math.BigDecimal
 import java.util.UUID
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/GetFilePayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/api/v3_1_8/GetFilePayment.kt
@@ -13,7 +13,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFileType
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3
 
 class GetFilePayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -12,9 +12,9 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.apache.http.entity.ContentType
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4
 import java.math.BigDecimal
 import java.util.*
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -14,7 +14,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.p
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions.assertThat
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.util.UUID
 
 class CreateInternationalPayment(

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -13,9 +13,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5
 
 class GetInternationalPayment(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentDetails.kt
@@ -9,9 +9,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 
 class GetInternationalPaymentDetails(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -18,10 +18,10 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6
 import java.math.BigDecimal
 import java.util.*
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -10,7 +10,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 
 class GetInternationalPaymentsConsentFundsConfirmation(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
@@ -11,7 +11,7 @@ import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBWriteInterna
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
 
 class GetInternationalPaymentsConsents(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -15,7 +15,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.s
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.util.UUID
 
 class CreateInternationalScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -13,9 +13,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6
 
 class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentDetails.kt
@@ -9,9 +9,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 
 class GetInternationalScheduledPaymentDetails(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -19,10 +19,10 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6
 import java.math.BigDecimal
 import java.util.*
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
@@ -10,7 +10,7 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 
 class GetInternationalScheduledPaymentsConsentFundsConfirmation(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
@@ -8,7 +8,7 @@ import com.forgerock.sapi.gateway.ob.uk.framework.consent.ConsentFactoryRegistry
 import com.forgerock.sapi.gateway.ob.uk.framework.consent.payment.OBWriteInternationalScheduledConsent5Factory
 import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType
 
 class GetInternationalScheduledPaymentsConsents(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/CreateInternationalStandingOrder.kt
@@ -19,7 +19,7 @@ import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.s
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.v3.payment.*
 import java.util.UUID
 
 class CreateInternationalStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrder.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrder.kt
@@ -15,8 +15,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForA
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.standing.orders.consents.api.v3_1_8.CreateInternationalStandingOrderConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7
 
 class GetInternationalStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrderDetails.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/api/v3_1_8/GetInternationalStandingOrderDetails.kt
@@ -9,8 +9,8 @@ import com.forgerock.sapi.gateway.ob.uk.support.discovery.getPaymentsApiLinks
 import com.forgerock.sapi.gateway.ob.uk.support.payment.PaymentFactory
 import com.forgerock.sapi.gateway.ob.uk.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1
 
 class GetInternationalStandingOrderDetails(
     val version: OBVersion,

--- a/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/ob/uk/tests/functional/payment/international/standing/orders/consents/api/v3_1_8/CreateInternationalStandingOrderConsents.kt
@@ -17,9 +17,9 @@ import com.forgerock.sapi.gateway.ob.uk.support.payment.*
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7
 import java.util.*
 
 class CreateInternationalStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {


### PR DESCRIPTION
OB datamodel classes have been moved under a v3 pkg in the latest version of common.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1477