### PR TITLE
1658: Tests should work against non pairwise deployments

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/data/DynamicRegistration.kt
@@ -27,7 +27,8 @@ data class RegistrationRequest(
                 )
         ).joinToString(separator = " "),
 
-        val subject_type: String = "pairwise",
+        val subject_type: String = if (asDiscovery.subject_types_supported.contains("pairwise")) "pairwise"
+        else asDiscovery.subject_types_supported[0],
         val token_endpoint_auth_method: String = CLIENT_AUTH_METHOD,
         val token_endpoint_auth_signing_alg: String = "PS256",
         val tls_client_auth_subject_dn: String


### PR DESCRIPTION
If pairwise is not available as subject_types_supported value in the as well known response for the deployment, then the DCR reqistration request will now use the first value from that array, which is supported.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1658