### PR TITLE
1718: Fix outdated dependancy for OB Func Tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("com.sun.xml.bind:jaxb-impl:${jaxbVersion}")
 
     implementation("com.github.kittinunf.fuel:fuel:2.2.1")
-    implementation("com.github.kittinunf.fuel:fuel-jackson:2.2.1")
+    implementation("com.github.kittinunf.fuel:fuel-jackson:2.2.3")
     implementation("com.github.kittinunf.fuel:fuel-gson:2.2.1")
     implementation("com.google.code.gson:gson:2.9.0")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.8")


### PR DESCRIPTION
Bump fuel-jackson to next available version `2.2.3`

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1718