### PR TITLE
OpenIG-9694: Update Signing and Transport KID for OB V4

### DIFF
--- a/gradle/profiles/profile-ob-sandbox-v4.gradle.kts
+++ b/gradle/profiles/profile-ob-sandbox-v4.gradle.kts
@@ -53,7 +53,7 @@ val userDebtorAccountIdentification by extra("01233243245676")
 val userAccountId by extra ("01233243245676")
 
 // Kid's
-val eidasTestSigningKid by extra("jSlqTZu6fidhnb89-v-rY01TEHY")
+val eidasTestSigningKid by extra("m6ieu1jW72qt2bm9IJYlna8sz_8")
 val aspspJwtSignerKid by extra("R3MviZ4QUPEDJm7RS3Mw")
 
 // Expected path to find the Certificates used for test purposes

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
@@ -22,7 +22,7 @@ val USER_ACCOUNT_ID = System.getenv("userAccountId") ?: "01233243245676"
 
 val OB_TPP_OB_EIDAS_TEST_SIGNING_KID =
     System.getenv("eidasTestSigningKid") ?: "2yNjPOCjpO8rcKg6_lVtWzAQR0U"
-val OB_TPP_PRE_EIDAS_SIGNING_KID = System.getenv("preEidasTestSigningKid") ?: "ymG3t1EuCt_u2_TORkTAhWaEh0M"
+val OB_TPP_PRE_EIDAS_SIGNING_KID = System.getenv("preEidasTestSigningKid") ?: "mvclNnEzM50-PpSHb_qRtqEZjlw"
 
 val AM_COOKIE_NAME = System.getenv("amCookieName") ?: "iPlanetDirectoryPro"
 


### PR DESCRIPTION
Update KIDs so that new automated testing certificates can be used for V4 testing in release environment

A 4.0.5 image will be created for Functional Tests following this merge

Issue: https://pingidentity.atlassian.net/jira/software/c/projects/OPENIG/boards/1322?selectedIssue=OPENIG-9694