### PR TITLE
OPENIG-9865 Add Encore demo sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ gradle all [--rerun-tasks] [-Pprofile]
   ```bash
   gradle test --tests "com.forgerock.sapi.gateway.ob.uk.tests.payment.domestic.SingleDomesticPaymentTest.shouldCreateSingleDomesticPayment_v3_1_2" -Pprofile=my-profile
   ```
+
+## Run gradle tests manually - with `make`
+
+### All test
+  ```bash
+  make runTests [profile=<profile-name>]
+  ```
+  Example
+  ```bash
+  make runTests profile=wmorrison365fr-ob    # Default profile used is dev-cdk-ob
+  ```
+
+### Single test
+  ```bash
+  make runTests ":singleTest --tests x.x.y.y.TestClass.testMethod" [profile=<profile-name>]
+  ```
+  Example
+  ```bash
+  make runTests profile=wmorrison365fr-ob tests=vcom.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.standing.orders.junit.v4_0_0.GetInternationalStandingOrderTest.shouldGetInternationalStandingOrders_withReadRefund_v4_0_0"
+```
+
 # Pipelines
 ## Codefresh pipeline variables table
 

--- a/gradle/profiles/profile-dev-cdk-ob.gradle.kts
+++ b/gradle/profiles/profile-dev-cdk-ob.gradle.kts
@@ -44,6 +44,9 @@ val environment by extra("dev-cdk-ob")
 val amCookieName by extra("iPlanetDirectoryPro")
 val asIGServer by extra("https://as-sapig.$environment.forgerock.financial")
 val rsIGServer by extra("https://rs-sapig.$environment.forgerock.financial")
+  // By default non-mtls hostname is transformed for mtls, but if a non-uniform value is required then provide below
+  // val asIGServerMtls by extra("https://my-as-mtls-sapig-$environment...")
+  // val rsIGServerMtls by extra("https://my-rs-mtls-sapig-$environment...")
 
 // PSU User configuration
 // needs to be a UUID and match with the value set in the use data initialiser

--- a/gradle/profiles/profile-devops-ob.gradle.kts
+++ b/gradle/profiles/profile-devops-ob.gradle.kts
@@ -44,6 +44,9 @@ val environment by extra ("devops-ob")
 val amCookieName by extra("iPlanetDirectoryPro")
 val asIGServer by extra("https://as-sapig.$environment.forgerock.financial")
 val rsIGServer by extra("https://rs-sapig.$environment.forgerock.financial")
+  // By default non-mtls hostname is transformed for mtls, but if a non-uniform value is required then provide below
+  // val asIGServerMtls by extra("https://my-as-mtls-sapig-$environment...")
+  // val rsIGServerMtls by extra("https://my-rs-mtls-sapig-$environment...")
 
 // PSU User configuration
 // needs to be a UUID and match with the value set in the use data initialiser

--- a/gradle/profiles/profile-encore-demo.gradle.kts
+++ b/gradle/profiles/profile-encore-demo.gradle.kts
@@ -39,14 +39,15 @@ val ssaMatlsUrl by extra("https://matls-dirapi.$obHostSufix/organisation/tpp/{or
 /**
  * Functional tests configuration
  */
-// servers
-val environment by extra ("dev-aic-ob")
-val amCookieName by extra("9cc10c563dded16")
-val asIGServer by extra("https://as-sapig.$environment.forgerock.financial")
-val rsIGServer by extra("https://rs-sapig.$environment.forgerock.financial")
-  // By default non-mtls hostname is transformed for mtls, but if a non-uniform value is required then provide below
-  // val asIGServerMtls by extra("https://my-as-mtls-sapig-$environment...")
-  // val rsIGServerMtls by extra("https://my-rs-mtls-sapig-$environment...")
+// servers - sample sapig-ob-mr1
+val environment by extra("sapig-ob-mr1")
+val amCookieName by extra("cfaba3b41129a6e")
+// as-sapig-ob-mr1.encore.pingidentity.com
+val asIGServer by extra("https://as-$environment.encore.pingidentity.com")
+val rsIGServer by extra("https://rs-$environment.encore.pingidentity.com")
+// non-uniform mtls hostnames provided - e.g. as-mtls-sapig-sapig-ob-mr1.encore.pingidentity.com
+val asIGServerMtls by extra("https://as-mtls-sapig-$environment.encore.pingidentity.com")
+val rsIGServerMtls by extra("https://rs-mtls-sapig-$environment.encore.pingidentity.com")
 
 // PSU User configuration
 // needs to be a UUID and match with the value set in the use data initialiser
@@ -58,7 +59,7 @@ val userAccountId by extra ("01233243245676")
 
 // Kid's
 val eidasTestSigningKid by extra("m6ieu1jW72qt2bm9IJYlna8sz_8")
-val aspspJwtSignerKid by extra("R3MviZ4QUPEDJm7RS3Mw")
+val aspspJwtSignerKid by extra("o5xN09cvkzpLplq1mKQ8CsWabYU")
 
 // Expected path to find the Certificates used for test purposes
 val eidasOBSealKey by extra("./certificates/OBSeal.key")

--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/configuration/Config.kt
@@ -8,9 +8,8 @@ val AS_IG_SERVER = System.getenv("asIGServer") ?: "https://as-sapig.dev-cdk-ob.f
 val RS_IG_SERVER = System.getenv("rsIGServer") ?: "https://rs-sapig.dev-cdk-ob.forgerock.financial"
 
 // mtls is a subdomain of the gateway domain
-val AS_MTLS_SERVER = AS_IG_SERVER.replace("https://as-", "https://as-mtls.")
-val RS_MTLS_SERVER = RS_IG_SERVER.replace("https://rs-", "https://rs-mtls.")
-
+val AS_MTLS_SERVER = System.getenv("asIGServerMtls") ?: AS_IG_SERVER.replace("https://as-", "https://as-mtls.")
+val RS_MTLS_SERVER = System.getenv("rsIGServerMtls") ?: RS_IG_SERVER.replace("https://rs-", "https://rs-mtls.")
 
 val RCS_DECISION_API_URI = "$RS_IG_SERVER/rcs/api/consent/decision"
 


### PR DESCRIPTION
OPENIG-9865 Add Encore demo sample config: see `profile-encore-demo.gradle.kts` which is referncing env sapig-ob-mr1.

Also provided a means of managing non-uniform MTLS endpoints (through substitution in the specific profile):
- see usage in `profile-encore-demo.gradle.kts`

Sample usage(s):
- New encore-demo env tests:
```
make runTests profile=encore-demo
```
- Single test variety:
```
make runTests profile=wmorrison365fr-ob tests=":singleTest --tests com.forgerock.sapi.gateway.ob.uk.tests.functional.payment.international.standing.orders.junit.v4_0_0.GetInternationalStandingOrderTest.shouldGetInternationalStandingOrders_withReadRefund_v4_0_0"
```
