### PR TITLE
Fix CreateTppCallback to compile against JUnit 6

### DIFF
--- a/src/main/kotlin/com/forgerock/sapi/gateway/framework/extensions/junit/CreateTppCallback.kt
+++ b/src/main/kotlin/com/forgerock/sapi/gateway/framework/extensions/junit/CreateTppCallback.kt
@@ -8,22 +8,22 @@ import org.junit.jupiter.api.extension.*
 
 
 class CreateTppCallback : BeforeAllCallback, BeforeEachCallback, ParameterResolver {
-    override fun supportsParameter(parameterContext: ParameterContext?, extensionContext: ExtensionContext?): Boolean {
-        return TppResource::class.java == parameterContext?.parameter?.type
+    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean {
+        return TppResource::class.java == parameterContext.parameter.type
     }
 
-    override fun resolveParameter(parameterContext: ParameterContext?, extensionContext: ExtensionContext?): Any {
-        return extensionContext?.root?.getStore(ExtensionContext.Namespace.GLOBAL)
-            ?.getOrComputeIfAbsent<String, TppResource>(
+    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any? {
+        return extensionContext.root.getStore(ExtensionContext.Namespace.GLOBAL)
+            .getOrComputeIfAbsent<String, TppResource>(
                 "tppResource",
                 { TppResource(initFuelAsNewTpp().apply { dynamicRegistration() }) },
                 TppResource::class.java
-            )!!
+            )
     }
 
-    override fun beforeEach(context: ExtensionContext?) {
-        val tpp: TppResource? = context?.root?.getStore(ExtensionContext.Namespace.GLOBAL)
-            ?.getOrComputeIfAbsent<String, TppResource>(
+    override fun beforeEach(context: ExtensionContext) {
+        val tpp: TppResource? = context.root.getStore(ExtensionContext.Namespace.GLOBAL)
+            .getOrComputeIfAbsent<String, TppResource>(
                 "tppResource",
                 { TppResource(initFuelAsNewTpp().apply { dynamicRegistration() }) },
                 TppResource::class.java
@@ -45,7 +45,7 @@ class CreateTppCallback : BeforeAllCallback, BeforeEachCallback, ParameterResolv
                 "tppResource",
                 { TppResource(initFuelAsNewTpp().apply { dynamicRegistration() }) },
                 TppResource::class.java
-            )
+            )!!
         // Need to init fuel with transport keys as we may load cached result
 
         initFuel(


### PR DESCRIPTION
## Summary

- JUnit 6 (introduced via `openig-bom` transitively through `secure-api-gateway-parent:5.3.0-SNAPSHOT`) changed the `ParameterResolver` and `BeforeEachCallback` interface signatures to use non-nullable parameters
- Updated `CreateTppCallback` method signatures to remove `?` from `ParameterContext` and `ExtensionContext` params
- Updated `resolveParameter` return type from `Any` to `Any?` to match new interface contract
- Removed unnecessary null-safe (`?.`) calls now that params are non-nullable
- Added `!!` to `beforeAll`'s `getOrComputeIfAbsent` call since it now returns `T?`

IG change bumping to junit 6: [IG PR #7783](https://github.com/ping-rocks/openig/pull/7783)

## Test plan

- [x] `./gradlew compileKotlin` passes with no errors
- [x] Run `GetAccountsTest` via `make runTests profile=dev-cdk-ob tests=":singleTest --tests com.forgerock.sapi.gateway.ob.uk.tests.functional.account.accounts.junit.v4_0_0.GetAccountsTest"` against a dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)